### PR TITLE
Fix fallback port if tsdproxy.container_port not specified

### DIFF
--- a/internal/containers/containers.go
+++ b/internal/containers/containers.go
@@ -67,17 +67,17 @@ func (c *Container) GetName() string {
 }
 
 func (c *Container) GetPort() (string, bool) {
-	// If Label is defined, get the container port
-	if customContainerPort, ok := c.Info.Config.Labels[LabelContainerPort]; ok {
+	// If Label is defined and not empty, get the label value
+	if customContainerPort, ok := c.Info.Config.Labels[LabelContainerPort]; ok && customContainerPort != "" {
 		return customContainerPort, true
 	}
 
-	// Otherwise, retrieve the PortMap object and find the first mapped port
+	// Otherwise, retrieve the PortMap object and find the first non-empty mapped port
 	for internalBind := range c.Info.NetworkSettings.Ports {
 		if len(internalBind) > 0 {
 			// Value will look like "80/tcp", we want "80"
 			internalPort := strings.Split(string(internalBind), "/")
-			if len(internalPort) > 0 {
+			if len(internalPort) > 0 && internalPort[0] != "" {
 				return internalPort[0], true
 			}
 		}

--- a/internal/containers/containers.go
+++ b/internal/containers/containers.go
@@ -68,14 +68,18 @@ func (c *Container) GetName() string {
 
 func (c *Container) GetPort() (string, bool) {
 	// If Label is defined, get the container port
-	//
 	if customContainerPort, ok := c.Info.Config.Labels[LabelContainerPort]; ok {
 		return customContainerPort, true
 	}
 
-	for _, bind := range c.Info.NetworkSettings.Ports {
-		if len(bind) > 0 {
-			return bind[0].HostPort, true
+	// Otherwise, retrieve the PortMap object and find the first mapped port
+	for internalBind := range c.Info.NetworkSettings.Ports {
+		if len(internalBind) > 0 {
+			// Value will look like "80/tcp", we want "80"
+			internalPort := strings.Split(string(internalBind), "/")
+			if len(internalPort) > 0 {
+				return internalPort[0], true
+			}
 		}
 	}
 


### PR DESCRIPTION
TsDProxy expects the internal port of a container, and currently the fallback of looking for the first mapped `HostPort` is incorrect if the internal and external ports are different. `HostPort` will report the external port. This change will correctly retrieve the internal port of the first mapped port on the container.