### PR TITLE
Add support for Docker network

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -25,12 +25,13 @@ type (
 	// Config stores complete configuration.
 	//
 	Config struct {
-		PublicURL   string `default:"http://localhost:8080"`
-		DataDir     string `default:"/data/"`
-		AuthKey     string
-		AuthKeyFile string
-		Hostname    string `default:"127.0.0.1"`
-		ControlURL  string
+		PublicURL      string `default:"http://localhost:8080"`
+		DataDir        string `default:"/data/"`
+		AuthKey        string
+		AuthKeyFile    string
+		Hostname       string `default:"127.0.0.1"`
+		ControlURL     string
+		IngressNetwork string
 
 		Log  LogConfig
 		HTTP HTTPConfig

--- a/internal/proxymanager/proxymanager.go
+++ b/internal/proxymanager/proxymanager.go
@@ -113,7 +113,7 @@ func (pm *ProxyManager) SetupProxy(ctx context.Context, containerID string) {
 
 	// Create a new container
 	//
-	container, err := containers.NewContainer(ctx, containerID, pm.docker, pm.config.Hostname, pm.config.AuthKey)
+	container, err := containers.NewContainer(ctx, containerID, pm.docker, pm.config.Hostname, pm.config.AuthKey, pm.config.IngressNetwork)
 	if err != nil {
 		pm.Log.Error().Err(err).Str("containerID", containerID).Msg("Error creating container")
 		return


### PR DESCRIPTION
Implements #18

This allows proxying to services inside the Docker network specified by `TSDPROXY_INGRESSNETWORK`.

This is inspired by [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy?tab=readme-ov-file#basic-usage-example-using-docker-compose), although I've chosen to only support a single ingress network for the time being (compared to caddy-docker-proxy).

<details><summary>Testing Instructions</summary>
<p>

1. Clone + checkout `https://github.com/simonhammes/tsdproxy/tree/18-support-docker-network`
2. Create the `.yml` files + the `.env` file (see below)
3. `docker compose up -d --build`

#### tsdproxy.yml

```yml
services:
  tsdproxy:
    # TODO: This should be the path to your local checkout of the fork
    build: tsdproxy
    environment:
      # TODO: Enter your AUTHKEY
      - TSDPROXY_AUTHKEY=
      - TSDPROXY_INGRESSNETWORK=tsdproxy-net
      - DOCKER_HOST=unix:///var/run/docker.sock
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - tsdproxy-data:/data
    networks:
      - tsdproxy-net

volumes:
  tsdproxy-data:

networks:
  tsdproxy-net:
    name: tsdproxy-net
```

#### nginx.yml

```yml
services:
  nginx:
    image: nginx:1.27
    container_name: nginx
    networks:
      - tsdproxy-net
    labels:
      tsdproxy.enable: true
      tsdproxy.container_port: 80

networks:
  tsdproxy-net:
    name: tsdproxy-net
```

#### .env

```ini
COMPOSE_FILE='tsdproxy.yml,nginx.yml'
COMPOSE_PATH_SEPARATOR=','
```

</p>
</details> 

You should now be able to access `https://nginx.<YOUR_TAILNET>.ts.net` :rocket: 