### PR TITLE
Fix log level env var in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ services:
       TSDPROXY_HOSTNAME: 10.0.10.0
       # TSDPROXY_AUTHKEYFILE: /run/secrets/authkey
       # TSDPROXY_DATADIR: /data
-      # TSDPROXY_LOGLEVEL: info
+      # TSDPROXY_LOG_LEVEL: info
       # TSDPROXY_CONTAINERACCESSLOG: true
 
     # secrets:
@@ -108,7 +108,7 @@ volumes:
 | TSDPROXY_HOSTNAME           | Yes      | LAN IP address or name of docker host machine (cannot use localhost or 127.0.0.1 if using bridge network) |
 | TSDPROXY_AUTHKEYFILE        | No       | Path to file containing the authkey (incompatible with Docker Secrets)                                    |
 | TSDPROXY_DATADIR            | No       | Custom internal directory for data (defaults to /data)                                                    |
-| TSDPROXY_LOGLEVEL           | No       | Log level (defaults to info)                                                                              |
+| TSDPROXY_LOG_LEVEL          | No       | Log level (defaults to info)                                                                              |
 | TSDPROXY_CONTAINERACCESSLOG | No       | Enable proxy access log for tagged containers (defaults to true)                                          |
 
 #### Example target container using TsDProxy


### PR DESCRIPTION
While investigating [issue #33](https://github.com/almeidapaulopt/tsdproxy/issues/33), I was trying to get more detailed log output. Setting `TSDPROXY_LOGLEVEL` wasn't having any effect. Looking at the code that ingests the config in [config.go](https://github.com/almeidapaulopt/tsdproxy/blob/92674fc3c8e7421d9fc3e8ac131f4423ebdbc381/internal/core/config.go#L35), I deduced it needed a separator between `LOG` and `LEVEL`. Setting `TSDPROXY_LOG_LEVEL` to `debug` started giving more verbose output. This change updates the doc to match my finding.