### PR TITLE
Enable Hostname-Based Targeting in tsdproxy to Eliminate Port Exposure

### DIFF
--- a/internal/containers/containers.go
+++ b/internal/containers/containers.go
@@ -94,6 +94,13 @@ func (c *Container) getTargetHostname(hostname string) string {
 		return c.Info.NetworkSettings.IPAddress
 	}
 
+	// Check for network aliases and return the first available alias
+	for _, network := range c.Info.NetworkSettings.Networks {
+		if len(network.Aliases) > 0 {
+			return network.Aliases[0]
+		}
+	}
+
 	// return localhost if container same as host to serve the dashboard
 	//
 	osname, err := os.Hostname()


### PR DESCRIPTION
## Summary
This update enables tsdproxy to retrieve and use the target container's hostname via network aliases, allowing it to connect directly without the need to expose additional ports.

## Benefits
Enhanced Security: Reduces potential attack surface by eliminating the need for exposed ports.
Simplified Configuration: Accessing containers by hostname streamlines the network configuration and reduces complexity.

## Implementation Details
tsdproxy now queries container aliases to determine the hostname, leveraging Docker's internal DNS to route traffic directly to the target container.

Example:

`services:
  tsdproxy:
    image: my-tsdproxy:arm64
    container_name: tsdproxy
    environment:
      DOCKER_HOST: unix:///var/run/docker.sock
      TSDPROXY_AUTHKEY: ${TAILSCALE_AUTHKEY}
      TSDPROXY_HOSTNAME: localhost
    volumes:
      - /config/path/tsdproxy:/data
      - /var/run/docker.sock:/var/run/docker.sock
    restart: unless-stopped

  tautulli:
    image: lscr.io/linuxserver/tautulli:latest
    container_name: tautulli
    environment:
      PUID: 1000
      PGID: 1000
      TZ: Etc/UTC
    volumes:
      - /config/path:/config
    restart: unless-stopped
    labels:
      tsdproxy.enable: "true"
      tsdproxy.container_port: 8181
`