### PR TITLE
Update containers.go

### DIFF
--- a/internal/containers/containers.go
+++ b/internal/containers/containers.go
@@ -26,6 +26,7 @@ const (
 	LabelFunnel        = LabelPrefix + "funnel"
 	LabelAuthKey       = LabelPrefix + "authkey"
 	LabelAuthKeyFile   = LabelPrefix + "authkeyfile"
+	LabelContainerHost  = LabelPrefix + "container_host"
 )
 
 type Container struct {
@@ -65,6 +66,13 @@ func NewContainer(ctx context.Context, containerID string, docker *client.Client
 	if err := container.setAuthKeyFromAuthFile(); err != nil {
 		return nil, fmt.Errorf("error setting auth key from file : %w", err)
 	}
+
+	// Override TargetHostname if LabelContainerHost is defined
+	containerHost := container.getLabelString(LabelContainerHost, "")
+	if containerHost != "" {
+		container.TargetHostname = containerHost
+	}
+	
 	return container, nil
 }
 


### PR DESCRIPTION
Added a new label `tsdproxy.container_host`. This should be the same as the container name, and Docker DNS will resolve it. If this label is present then it overrides the value of `container.TargetHostname`. Doing this way makes sure that the dashboard works when this label is not present. Both containers must be under the same network. Tested and works.

Solves https://github.com/almeidapaulopt/tsdproxy/issues/18 and implements https://github.com/almeidapaulopt/tsdproxy/pull/32#pullrequestreview-2433318049