### PR TITLE
Preserve x-forwarded-{for,host,proto} headers

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -61,7 +61,15 @@ func NewProxy(log zerolog.Logger,
 
 	// Create the reverse proxy
 	//
-	proxy.reverseProxy = httputil.NewSingleHostReverseProxy(pcfg.TargetURL)
+	proxy.reverseProxy = &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(pcfg.TargetURL)
+			r.Out.Host = r.In.Host
+
+			r.Out.Header["X-Forwarded-For"] = r.In.Header["X-Forwarded-For"]
+			r.SetXForwarded()
+		},
+	}
 
 	// Create the proxyProvider proxy
 	//


### PR DESCRIPTION
This change preserves the x-forwarded-{for,host,proto} headers because they’re removed by default in the current implementation.

It was added & then removed upstream:

Addition: https://go-review.googlesource.com/c/go/+/407414
Subsequent Removal: https://go-review.googlesource.com/c/go/+/457595

Comment from the removal:

```
Revert the change to ReverseProxy when using a Director func.
Users who want a convenient way to set X-Forwarded-* headers to
reasonable values can migrate to Rewrite at their convenience,
and users depending on the current behavior will be unaffected.
```