### PR TITLE
feat: use provider ControlURL directly in Tailscale proxy setup

### DIFF
--- a/internal/proxyproviders/tailscale/provider.go
+++ b/internal/proxyproviders/tailscale/provider.go
@@ -65,7 +65,7 @@ func (c *Client) NewProxy(config *proxyconfig.Config) (proxyproviders.Proxy, err
 			c.log.Trace().Msgf(format, args...)
 		},
 
-		ControlURL: c.getControlURL(config),
+		ControlURL: c.controlUrl,
 	}
 
 	// if verbose is set, use the info log level
@@ -80,12 +80,4 @@ func (c *Client) NewProxy(config *proxyconfig.Config) (proxyproviders.Proxy, err
 		config:   config,
 		tsServer: tserver,
 	}, nil
-}
-
-// getControlURL method returns the control URL
-func (c *Client) getControlURL(cfg *proxyconfig.Config) string {
-	if cfg.Tailscale.ControlURL == "" {
-		return proxyconfig.DefaultTailscaleControlURL
-	}
-	return cfg.Tailscale.ControlURL
 }


### PR DESCRIPTION
fix #98 

It seems the implementation was attempting to set `ControlURL` from the container configuration (I saw a TODO comment about this), but in my opinion, this doesn't make sense. `ControlURL` is a property that only makes sense at the provider configuration level. Am I right?