### PR TITLE
Correct environment variable in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     restart: unless-stopped
     environment:
       #- TSDPROXY_AUTHKEYFILE=/run/secrets/authkey
-      - TS_AUTHKEY=tskey-auth-is-not-actually-a-real-key
+      - TSDPROXY_AUTHKEY=tskey-auth-is-not-actually-a-real-key
       - TSDPROXY_DATADIR:/data
       - DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
### Problem
The `docker-compose.yaml` file used the environment variable `TS_AUTHKEY`, but the application code references `TSDPROXY_AUTHKEY`. This mismatch caused the environment variable to be ineffective during deployment.

### Solution
Updated `TS_AUTHKEY` to `TSDPROXY_AUTHKEY` in the `docker-compose.yaml` file to align with the application code.

### Impact
This change ensures the correct environment variable is used, allowing the application to function as intended.