### PR TITLE
docs: publish proxy dashboard port

### DIFF
--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -23,6 +23,8 @@ services:
       - datadir:/data
       - <PATH_TO_YOUR_CONFIG_DIR>:/config
     restart: unless-stopped
+    ports:
+      - "8080:8080"
 
 volumes:
   datadir:


### PR DESCRIPTION
The instructions require opening the dashboard, but the initial Compose service definition needs to publish them to the host first.