### PR TITLE
Feat: Support TCP proxy

### DIFF
--- a/dev/docker-compose-local.yaml
+++ b/dev/docker-compose-local.yaml
@@ -40,13 +40,13 @@ services:
   c4:
     image: linuxserver/openssh-server
     ports:
-      - 2222:22
+      - 2222:2222
     labels:
       - tsdproxy.enable=true
       - tsdproxy.name=ssh
       - tsdproxy.ephemeral=true
       - tsdproxy.dash.visible=true
-      - tsdproxy.port.1=22/tcp:22/tcp, no_autodetect,
+      - tsdproxy.port.1=22/tcp:2222/tcp
   s1:
     image: nginx
     ports:

--- a/dev/docker-compose-local.yaml
+++ b/dev/docker-compose-local.yaml
@@ -37,6 +37,16 @@ services:
     # networks:
     #   - c2
 
+  c4:
+    image: linuxserver/openssh-server
+    ports:
+      - 2222:22
+    labels:
+      - tsdproxy.enable=true
+      - tsdproxy.name=ssh
+      - tsdproxy.ephemeral=true
+      - tsdproxy.dash.visible=true
+      - tsdproxy.port.1=22/tcp:22/tcp, no_autodetect,
   s1:
     image: nginx
     ports:

--- a/internal/model/port.go
+++ b/internal/model/port.go
@@ -17,7 +17,6 @@ type (
 		ProxyProtocol string `validate:"string" yaml:"proxyProtocol"`
 		targets       []*url.URL
 		ProxyPort     int           `validate:"hostname_port" yaml:"proxyPort"`
-		TargetPort    int           `validate:"integer" yaml:"targetPort"`
 		TLSValidate   bool          `validate:"boolean" yaml:"tlsValidate"`
 		IsRedirect    bool          `validate:"boolean" yaml:"isRedirect"`
 		Tailscale     TailscalePort `validate:"dive" yaml:"tailscale"`
@@ -168,12 +167,7 @@ func parseTargetSegment(segment string, config *PortConfig) error {
 		return fmt.Errorf("error to parse url: %w", err)
 	}
 
-	port, err := strconv.Atoi(targetParts[0])
-	if err != nil {
-		return fmt.Errorf("error to parse port: %w", err)
-	}
 	config.targets = []*url.URL{urlParsed}
-	config.TargetPort = port
 	return nil
 }
 

--- a/internal/model/port.go
+++ b/internal/model/port.go
@@ -17,6 +17,7 @@ type (
 		ProxyProtocol string `validate:"string" yaml:"proxyProtocol"`
 		targets       []*url.URL
 		ProxyPort     int           `validate:"hostname_port" yaml:"proxyPort"`
+		TargetPort    int           `validate:"integer" yaml:"targetPort"`
 		TLSValidate   bool          `validate:"boolean" yaml:"tlsValidate"`
 		IsRedirect    bool          `validate:"boolean" yaml:"isRedirect"`
 		Tailscale     TailscalePort `validate:"dive" yaml:"tailscale"`
@@ -167,8 +168,12 @@ func parseTargetSegment(segment string, config *PortConfig) error {
 		return fmt.Errorf("error to parse url: %w", err)
 	}
 
+	port, err := strconv.Atoi(targetParts[0])
+	if err != nil {
+		return fmt.Errorf("error to parse port: %w", err)
+	}
 	config.targets = []*url.URL{urlParsed}
-
+	config.TargetPort = port
 	return nil
 }
 

--- a/internal/proxymanager/port.go
+++ b/internal/proxymanager/port.go
@@ -107,7 +107,7 @@ func newPortRedirect(ctx context.Context, pconfig model.PortConfig, log zerolog.
 }
 
 func newPortTCP(ctx context.Context, pconfig model.PortConfig, log zerolog.Logger) (*port, error) {
-	targetAddressWithPort := strings.Split(pconfig.GetFirstTarget().String(),"/")[1]
+	targetAddressWithPort := strings.Split(pconfig.GetFirstTarget().String(),"/")[2]
 	backend, err := net.ResolveTCPAddr("tcp", targetAddressWithPort)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving address to ResolveTCPAddr: %w", err)

--- a/internal/proxymanager/port.go
+++ b/internal/proxymanager/port.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"sync"
+	"strings"
 
 	"github.com/almeidapaulopt/tsdproxy/internal/consts"
 	"github.com/almeidapaulopt/tsdproxy/internal/core"
@@ -106,7 +107,8 @@ func newPortRedirect(ctx context.Context, pconfig model.PortConfig, log zerolog.
 }
 
 func newPortTCP(ctx context.Context, pconfig model.PortConfig, log zerolog.Logger) (*port, error) {
-	backend, err := net.ResolveTCPAddr("tcp", pconfig.GetFirstTarget().String())
+	targetAddressWithPort := strings.Split(pconfig.GetFirstTarget().String(),"/")[1]
+	backend, err := net.ResolveTCPAddr("tcp", targetAddressWithPort)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving address to ResolveTCPAddr: %w", err)
 	}

--- a/internal/proxymanager/port.go
+++ b/internal/proxymanager/port.go
@@ -16,6 +16,7 @@ import (
 	"github.com/almeidapaulopt/tsdproxy/internal/consts"
 	"github.com/almeidapaulopt/tsdproxy/internal/core"
 	"github.com/almeidapaulopt/tsdproxy/internal/model"
+
 	"github.com/rs/zerolog"
 )
 
@@ -102,6 +103,23 @@ func newPortRedirect(ctx context.Context, pconfig model.PortConfig, log zerolog.
 		cancel:     cancel,
 		httpServer: redirectHTTPServer,
 	}
+}
+
+func newPortTCP(ctx context.Context, pconfig model.PortConfig, log zerolog.Logger) (*port, error) {
+	backend, err := net.ResolveTCPAddr("tcp", pconfig.GetFirstTarget().String())
+	if err != nil {
+		return nil, fmt.Errorf("error resolving address to ResolveTCPAddr: %w", err)
+	}
+
+	newTCPProxy := NewTCPProxy(backend)
+
+	ctxPort, cancel := context.WithCancel(ctx)
+	return &port{
+		TCPProxy: newTCPProxy,
+		log:      log,
+		ctx:      ctxPort,
+		cancel:   cancel,
+	}, nil
 }
 
 func (p *port) startWithListener(l net.Listener) error {

--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -128,7 +128,8 @@ func (proxy *Proxy) initPorts() error {
 	var newPort *port
 	for k, v := range proxy.Config.Ports {
 		log := proxy.log.With().Str("port", k).Logger()
-		if v.ProxyProtocol == "tcp" {
+		switch {
+		case v.ProxyProtocol == "tcp":
 			target := strings.Split(proxy.providerProxy.GetURL(), "/")[2]
 			backend, err := net.ResolveTCPAddr("tcp", target+":"+strconv.Itoa(v.TargetPort))
 			if err != nil {
@@ -144,12 +145,10 @@ func (proxy *Proxy) initPorts() error {
 				ctx:      ctxPort,
 				cancel:   cancel,
 			}
-		} else {
-			if v.IsRedirect {
-				newPort = newPortRedirect(proxy.ctx, v, log)
-			} else {
-				newPort = newPortProxy(proxy.ctx, v, log, proxy.Config.ProxyAccessLog, proxy.ProviderUserMiddleware)
-			}
+		case v.IsRedirect:
+			newPort = newPortRedirect(proxy.ctx, v, log)
+		default:
+			newPort = newPortProxy(proxy.ctx, v, log, proxy.Config.ProxyAccessLog, proxy.ProviderUserMiddleware)
 		}
 
 		proxy.log.Debug().Any("port", newPort).Msg("newport")

--- a/internal/proxymanager/tcpProxy.go
+++ b/internal/proxymanager/tcpProxy.go
@@ -1,0 +1,101 @@
+package proxymanager
+
+import (
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
+	"io"
+	"net"
+	"syscall"
+)
+
+type TCPConn interface {
+	io.Writer
+	CloseWrite() error
+	io.Reader
+	CloseRead() error
+}
+
+// TCPProxy is a proxy for TCP connections. It implements the Proxy interface to
+// handle TCP traffic forwarding between the frontend and backend addresses.
+type TCPProxy struct {
+	//Logger       logger
+	listener     net.Listener
+	frontendAddr net.Addr
+	backendAddr  *net.TCPAddr
+}
+
+// NewTCPProxy creates a new TCPProxy.
+func NewTCPProxy(backendAddr *net.TCPAddr) *TCPProxy {
+	proxy := &TCPProxy{
+		backendAddr: backendAddr,
+	}
+	return proxy
+}
+
+func (proxy *TCPProxy) clientLoop(client *gonet.TCPConn, quit chan bool) {
+	backend, err := net.DialTCP("tcp", nil, proxy.backendAddr)
+	if err != nil {
+		//proxy.Logger.Printf("Can't forward traffic to backend tcp/%v: %s\n", proxy.backendAddr, err)
+		_ = client.Close()
+		return
+	}
+
+	event := make(chan int64)
+	broker := func(to, from TCPConn) {
+		written, err := io.Copy(to, from)
+		if err != nil {
+			// If the socket we are writing to is shutdown with
+			// SHUT_WR, forward it to the other end of the pipe:
+			if err, ok := err.(*net.OpError); ok && err.Err == syscall.EPIPE {
+				_ = from.CloseRead()
+			}
+		}
+		_ = to.CloseWrite()
+		event <- written
+	}
+
+	go broker(client, backend)
+	go broker(backend, client)
+
+	var transferred int64
+	for i := 0; i < 2; i++ {
+		select {
+		case written := <-event:
+			transferred += written
+		case <-quit:
+			// Interrupt the two brokers and "join" them.
+			_ = client.Close()
+			_ = backend.Close()
+			for ; i < 2; i++ {
+				transferred += <-event
+			}
+			return
+		}
+	}
+	_ = client.Close()
+	_ = backend.Close()
+}
+
+// Run starts forwarding the traffic using TCP.
+func (proxy *TCPProxy) Run(listener net.Listener) {
+	quit := make(chan bool)
+	defer close(quit)
+	proxy.listener = listener
+	proxy.frontendAddr = proxy.listener.Addr()
+	for {
+		client, err := proxy.listener.Accept()
+		if err != nil {
+			//proxy.Logger.Printf("Stopping proxy on tcp/%v for tcp/%v (%s)", proxy.frontendAddr, proxy.backendAddr, err)
+			return
+		}
+		go proxy.clientLoop(client.(*gonet.TCPConn), quit)
+	}
+}
+
+// Close stops forwarding the traffic.
+func (proxy *TCPProxy) Close() { _ = proxy.listener.Close() }
+
+// FrontendAddr returns the TCP address on which the proxy is listening.
+func (proxy *TCPProxy) FrontendAddr() net.Addr { return proxy.frontendAddr }
+
+// BackendAddr returns the TCP proxied address.
+func (proxy *TCPProxy) BackendAddr() net.Addr { return proxy.backendAddr }


### PR DESCRIPTION
Hi,

Like several others, I encountered a use case where I needed to connect via SSH to a remote Docker container and proxy raw TCP connections (see issues #252, #242, #221).

This PR introduces support for that feature. When a TCP protocol is specified in the Docker label (e.g. `tsdproxy.port.1=22/tcp:22/tcp,no_autodetect`), the proxy will use a TCP proxy instead of the default HTTP one.