### PR TITLE
Feat: Add proxy path feature

### DIFF
--- a/dev/docker-compose-local.yaml
+++ b/dev/docker-compose-local.yaml
@@ -12,7 +12,7 @@ services:
       - tsdproxy.funnel=true
       - tsdproxy.container_port=80
       - tsdproxy.dash.visible=true
-      # - tsdproxy.port.1=443/https:80/http, no_autodetect
+      # - tsdproxy.port.1=443/https/test:80/http, no_autodetect
     # networks:
     # - c1
 

--- a/internal/proxyproviders/tailscale/proxy.go
+++ b/internal/proxyproviders/tailscale/proxy.go
@@ -162,7 +162,14 @@ func (p *Proxy) watchStatus() {
 		case "Starting":
 			p.setStatus(model.ProxyStatusStarting, "", "")
 		case "Running":
-			p.setStatus(model.ProxyStatusRunning, strings.TrimRight(status.Self.DNSName, "."), "")
+			// if any, get TargetPath for port 443
+			var path = "/"
+			for _, c := range p.config.Ports {
+				if c.ProxyPort == 443 {
+					path = c.ProxyPath
+				}
+			}
+			p.setStatus(model.ProxyStatusRunning, strings.TrimRight(status.Self.DNSName, ".")+"/"+path, "")
 			if p.status != model.ProxyStatusRunning {
 				p.getTLSCertificates()
 			}


### PR DESCRIPTION
Hi,

This PR is related to the issue #153. I had a similar need, where the Pi-hole administration interface is located at `/admin`.

If you wish this feature to be implemented differently (for example, using a label like `tsdproxy.dash.path: "/login"`), let me know and I can adjust the implementation accordingly.