### PR TITLE
Feat: Support host.docker.internal if available

### DIFF
--- a/dev/docker-compose-dev.yaml
+++ b/dev/docker-compose-dev.yaml
@@ -17,6 +17,8 @@ services:
       - tsdproxy.dash.visible=false
     secrets:
       - authkey
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 secrets:
   authkey:

--- a/docs/content/docs/v2/getting-started.md
+++ b/docs/content/docs/v2/getting-started.md
@@ -25,7 +25,8 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 volumes:
   datadir:
 ```
@@ -46,7 +47,7 @@ defaultProxyProvider: default
 docker:
   local: # name of the docker target provider
     host: unix:///var/run/docker.sock # host of the docker socket or daemon
-    targetHostname: 172.31.0.1 # hostname or IP of docker server
+    targetHostname: host.docker.internal # hostname or IP of docker server (ex: host.docker.internal or 172.31.0.1)
     defaultProxyProvider: default # name of which proxy provider to use
 lists: {}
 tailscale:

--- a/docs/content/docs/v2/serverconfig.md
+++ b/docs/content/docs/v2/serverconfig.md
@@ -22,7 +22,7 @@ defaultProxyProvider: default
 docker:
   local: # Name of the Docker target provider
     host: unix:///var/run/docker.sock # Docker socket or daemon address
-    targetHostname: 172.31.0.1 # Docker server hostname or IP
+    targetHostname: host.docker.internal # hostname or IP of docker server (ex: host.docker.internal or 172.31.0.1)
     defaultProxyProvider: default # Default proxy provider for this Docker server
 lists:
   critical: # Name of the target list provider

--- a/internal/config/generateproviders.go
+++ b/internal/config/generateproviders.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/creasty/defaults"
@@ -40,6 +41,12 @@ func (c *config) generateDockerConfig() {
 
 	if os.Getenv("TSDPROXY_HOSTNAME") != "" {
 		docker.TargetHostname = os.Getenv("TSDPROXY_HOSTNAME")
+	}
+
+	// Check whether the hostname host.docker.internal can be resolved. This allows avoiding updates to the TargetHostname field in the configuration file.
+	ip, err := net.LookupIP("host.docker.internal")
+	if err == nil || len(ip) > 0 {
+		docker.TargetHostname = "host.docker.internal"
 	}
 
 	c.Docker[DockerDefaultName] = docker


### PR DESCRIPTION
This PR relates to issue #261. I encountered a similar problem where, upon recreating containers, the network would sometimes change, requiring a manual update to the configuration file. Using `host.docker.internal` eliminates this step.
