### PR TITLE
Update Icon document link

### DIFF
--- a/docs/content/docs/v2/providers/docker.md
+++ b/docs/content/docs/v2/providers/docker.md
@@ -228,7 +228,7 @@ labels:
 {{% details title="tsdproxy.dash.icon" %}}
 
 Sets the proxy icon on dashboard. If not defined, TSDProxy will try to find a
-icon based on the image name. See available icons in [icons](/docs/advanced/icons).
+icon based on the image name. See available icons in [icons](/docs/v2/advanced/icons/).
 
 ```yaml
 labels:


### PR DESCRIPTION
Link was broken and needed to be updated for v2 document location.