### PR TITLE
Remove Docker Swarm requirement for secrets

### DIFF
--- a/docs/content/docs/advanced/docker-secrets.md
+++ b/docs/content/docs/advanced/docker-secrets.md
@@ -7,15 +7,6 @@ the following example:
 
 {{% steps %}}
 
-### Requirements
-
-Make sure you have Docker Swarm enabled on your server.
-
-<https://docs.docker.com/engine/swarm/secrets/>
-
-"Docker secrets are only available to swarm services, not to standalone
-containers. To use this feature, consider adapting your container to run as a service."
-
 ### Add a docker secret
 
 We need to create a docker secret, which we can name `authkey` and store the Tailscale


### PR DESCRIPTION
There are secrets in Docker Compose also, not just Docker Swarm:

https://docs.docker.com/compose/how-tos/use-secrets/