### PR TITLE
Fix docs link

### DIFF
--- a/docs/content/docs/list.md
+++ b/docs/content/docs/list.md
@@ -94,6 +94,6 @@ music: # Name of the proxy
 > You only need to restart TSDProxy if your changes are in /config/tsdproxy.yaml
 
 > [!NOTE]
-> See available icons in [icons](/docs/advanced/icons).
+> See available icons in [icons](/tsdproxy/docs/advanced/icons).
 
 {{% /steps %}}


### PR DESCRIPTION
The icons docs link on this page redirects to a broken link

https://almeidapaulopt.github.io/tsdproxy/docs/list/


```
See available icons in [icons](https://almeidapaulopt.github.io/docs/advanced/icons).
```

https://almeidapaulopt.github.io/docs/advanced/icons

