### PR TITLE
Fix redirect creation from Docker labels

### DIFF
--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -192,7 +192,9 @@ func (c *container) getPorts() model.PortConfigList {
 			}
 		}
 
-		if !port.IsRedirect {
+		if port.IsRedirect {
+			ports[k] = port
+		} else {
 			port, err = c.generateTargetFromFirstTarget(port)
 			if err == nil {
 				ports[k] = port


### PR DESCRIPTION
The IsRedirect side of this conditional looks to have just been missed when this was written for v2. Redirects currently only get created when configured through a YAML list, not a Docker label.

Closes #381