### PR TITLE
feat(config): add TSDPROXY_* env var override system

### DIFF
--- a/docs/content/docs/v2/advanced/tailscale.md
+++ b/docs/content/docs/v2/advanced/tailscale.md
@@ -46,6 +46,32 @@ Restart TSDProxy to apply the changes.
 > If the proxy fails to authenticate after restarting, check the error logs.
 > Ensure the tags are correct and the OAuth client is enabled.
 
+#### Docker Compose with Environment Variables
+
+Instead of mounting a YAML config file, you can pass OAuth credentials via
+environment variables:
+
+```yaml {filename="docker-compose.yaml"}
+services:
+  tsdproxy:
+    image: almeidapaulopt/tsdproxy:latest
+    environment:
+      - TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTID=${TS_CLIENTID}
+      - TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTSECRET=${TS_SECRET}
+      - TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_TAGS=tag:tsdproxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - data:/data
+    ports:
+      - 8080:8080
+volumes:
+  data:
+```
+
+> [!Tip]
+> See [Environment Variable Overrides](../../serverconfig/#environment-variable-overrides)
+> for the full naming convention.
+
 {{% /steps %}}
 
 ### OAuth (Manual)

--- a/docs/content/docs/v2/serverconfig.md
+++ b/docs/content/docs/v2/serverconfig.md
@@ -58,6 +58,46 @@ log:
 proxyAccessLog: true # Enable container access logs (true/false)
 ```
 
+### Environment Variable Overrides
+
+Any configuration value can be set via environment variables using the naming
+convention `TSDPROXY_<PATH>`, where `<PATH>` is the uppercased config path with
+underscores separating each level.
+
+**Naming rules:**
+
+1. Start with `TSDPROXY_`
+2. Append each yaml key in uppercase, separated by `_`
+3. Multi-word yaml keys are written without separators (e.g., `defaultProxyProvider` → `DEFAULTPROXYPROVIDER`)
+4. For map fields (like `docker`, `providers`), the segment after the map name is the map key (lowercased)
+
+**Examples:**
+
+| Environment Variable | Config Path |
+|---------------------|-------------|
+| `TSDPROXY_LOG_LEVEL` | `log.level` |
+| `TSDPROXY_HTTP_PORT` | `http.port` |
+| `TSDPROXY_DEFAULTPROXYPROVIDER` | `defaultProxyProvider` |
+| `TSDPROXY_PROXYACCESSLOG` | `proxyAccessLog` |
+| `TSDPROXY_TAILSCALE_DATADIR` | `tailscale.dataDir` |
+| `TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTID` | `tailscale.providers.default.clientId` |
+| `TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTSECRET` | `tailscale.providers.default.clientSecret` |
+| `TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_TAGS` | `tailscale.providers.default.tags` |
+| `TSDPROXY_DOCKER_LOCAL_HOST` | `docker.local.host` |
+
+Environment variables override both the YAML file and struct defaults. Map
+entries that don't exist yet are auto-created with default values.
+
+> [!Note]
+> Map keys (e.g., provider names, docker server names) cannot contain
+> underscores since underscore is used as the path separator.
+
+> [!Important]
+> The legacy environment variables (`TSDPROXY_AUTHKEY`, `TSDPROXY_AUTHKEYFILE`,
+> `TSDPROXY_CONTROLURL`, `TSDPROXY_DATADIR`, `TSDPROXY_HOSTNAME`) from versions
+> prior to v0.6.0 are still supported during first-run config generation but are
+> not part of this override system.
+
 ### Configuration Sections
 
 #### log Section

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,6 +142,12 @@ func InitializeConfig() error {
 		log.Error().Err(err).Msg("error loading defaults")
 	}
 
+	// Apply environment variable overrides.
+	// Env vars override both the YAML file and struct defaults.
+	if err := applyEnvOverrides(Config); err != nil {
+		return err
+	}
+
 	// load auth keys from files
 	for _, d := range Config.Tailscale.Providers {
 		if d != nil && d.ClientSecret != "" && d.ClientID != "" {

--- a/internal/config/envoverride.go
+++ b/internal/config/envoverride.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2025 Paulo Almeida <almeidapaulopt@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/creasty/defaults"
+)
+
+// legacyEnvVars lists env vars handled by generateDefaultProviders that should
+// not be processed by the general override system.
+var legacyEnvVars = map[string]bool{
+	"TSDPROXY_AUTHKEY":     true,
+	"TSDPROXY_AUTHKEYFILE": true,
+	"TSDPROXY_CONTROLURL":  true,
+	"TSDPROXY_DATADIR":     true,
+	"TSDPROXY_HOSTNAME":    true,
+}
+
+// applyEnvOverrides applies TSDPROXY_* environment variable overrides to the
+// config struct. Each env var name is split by "_" (after stripping the
+// TSDPROXY_ prefix) and the resulting segments are matched against struct
+// fields via their yaml tags. Map fields (e.g. Docker, Providers) consume one
+// segment as the map key.
+//
+// Known limitation: map keys cannot contain underscores.
+func applyEnvOverrides(cfg *config) error {
+	for _, env := range os.Environ() {
+		name, value, ok := strings.Cut(env, "=")
+		if !ok || !strings.HasPrefix(name, "TSDPROXY_") {
+			continue
+		}
+		if legacyEnvVars[name] {
+			continue
+		}
+
+		segments := strings.Split(strings.TrimPrefix(name, "TSDPROXY_"), "_")
+		if err := setFieldBySegments(reflect.ValueOf(cfg).Elem(), segments, value); err != nil {
+			return fmt.Errorf("env %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// setFieldBySegments walks the struct tree using path segments and sets the
+// leaf value. It uses greedy matching: for each position it tries consuming
+// 1, 2, ... segments to match a field's uppercased yaml tag. This handles
+// multi-word yaml tags like "defaultProxyProvider" → DEFAULTPROXYPROVIDER.
+func setFieldBySegments(v reflect.Value, segments []string, value string) error {
+	if len(segments) == 0 {
+		return fmt.Errorf("no path segments remaining")
+	}
+
+	t := v.Type()
+
+	for n := 1; n <= len(segments); n++ {
+		combined := strings.ToUpper(strings.Join(segments[:n], ""))
+		remaining := segments[n:]
+
+		fieldIdx := findFieldByYAMLTag(t, combined)
+		if fieldIdx < 0 {
+			continue
+		}
+
+		fieldVal := v.Field(fieldIdx)
+
+		switch {
+		case fieldVal.Kind() == reflect.Map && len(remaining) > 0:
+			return setMapField(fieldVal, remaining, value)
+
+		case fieldVal.Kind() == reflect.Struct && len(remaining) > 0:
+			return setFieldBySegments(fieldVal, remaining, value)
+
+		case isLeafKind(fieldVal.Kind()) && len(remaining) == 0:
+			return setLeafValue(fieldVal, value)
+		}
+
+		// Match found but not usable with current remaining segments;
+		// try consuming more segments.
+	}
+
+	return fmt.Errorf("unrecognized config path: %s", strings.Join(segments, "_"))
+}
+
+// findFieldByYAMLTag returns the index of the struct field whose uppercased
+// yaml tag matches upperName, or -1 if not found.
+func findFieldByYAMLTag(t reflect.Type, upperName string) int {
+	for i := 0; i < t.NumField(); i++ {
+		yamlTag := strings.Split(t.Field(i).Tag.Get("yaml"), ",")[0]
+		if yamlTag != "" && yamlTag != "-" && strings.ToUpper(yamlTag) == upperName {
+			return i
+		}
+	}
+	return -1
+}
+
+// setMapField handles a map[string]*Struct field. The first segment is the map
+// key (lowercased); the rest navigate into the struct value.
+func setMapField(mapVal reflect.Value, segments []string, value string) error {
+	mapKey := strings.ToLower(segments[0])
+	remaining := segments[1:]
+
+	if len(remaining) == 0 {
+		return fmt.Errorf("map key %q requires a sub-field", mapKey)
+	}
+
+	keyVal := reflect.ValueOf(mapKey)
+	elemType := mapVal.Type().Elem() // *Struct
+
+	// Look up or create the map entry.
+	entry := mapVal.MapIndex(keyVal)
+	if !entry.IsValid() || entry.IsNil() {
+		newEntry := reflect.New(elemType.Elem())
+		if err := defaults.Set(newEntry.Interface()); err != nil {
+			return fmt.Errorf("setting defaults for new map entry %q: %w", mapKey, err)
+		}
+		mapVal.SetMapIndex(keyVal, newEntry)
+		entry = mapVal.MapIndex(keyVal)
+	}
+
+	return setFieldBySegments(entry.Elem(), remaining, value)
+}
+
+// setLeafValue converts the string value and sets it on the reflect.Value.
+func setLeafValue(v reflect.Value, s string) error {
+	//nolint:exhaustive // only these kinds are used in config structs
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString(s)
+
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return fmt.Errorf("invalid bool value %q: %w", s, err)
+		}
+		v.SetBool(b)
+
+	case reflect.Uint16:
+		n, err := strconv.ParseUint(s, 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid uint16 value %q: %w", s, err)
+		}
+		v.SetUint(n)
+
+	default:
+		return fmt.Errorf("unsupported field type: %s", v.Kind())
+	}
+
+	return nil
+}
+
+// isLeafKind returns true for kinds that represent settable leaf values.
+func isLeafKind(k reflect.Kind) bool {
+	return k != reflect.Struct && k != reflect.Map
+}

--- a/internal/config/envoverride_test.go
+++ b/internal/config/envoverride_test.go
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: 2025 Paulo Almeida <almeidapaulopt@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"testing"
+
+	"github.com/creasty/defaults"
+)
+
+func newTestConfig(t *testing.T) *config {
+	t.Helper()
+
+	cfg := &config{}
+	cfg.Tailscale.Providers = make(map[string]*TailscaleServerConfig)
+	cfg.Docker = make(map[string]*DockerTargetProviderConfig)
+	cfg.Lists = make(map[string]*ListTargetProviderConfig)
+
+	if err := defaults.Set(cfg); err != nil {
+		t.Fatalf("defaults.Set: %v", err)
+	}
+
+	return cfg
+}
+
+func TestApplyEnvOverrides_SimpleString(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_DEFAULTPROXYPROVIDER", "myprovider")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.DefaultProxyProvider != "myprovider" {
+		t.Errorf("DefaultProxyProvider = %q, want %q", cfg.DefaultProxyProvider, "myprovider")
+	}
+}
+
+func TestApplyEnvOverrides_BoolField(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_PROXYACCESSLOG", "false")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.ProxyAccessLog != false {
+		t.Errorf("ProxyAccessLog = %v, want false", cfg.ProxyAccessLog)
+	}
+}
+
+func TestApplyEnvOverrides_Uint16Field(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_HTTP_PORT", "9090")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.HTTP.Port != 9090 {
+		t.Errorf("HTTP.Port = %d, want 9090", cfg.HTTP.Port)
+	}
+}
+
+func TestApplyEnvOverrides_NestedStruct(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_LOG_LEVEL", "debug")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Log.Level != "debug" {
+		t.Errorf("Log.Level = %q, want %q", cfg.Log.Level, "debug")
+	}
+}
+
+func TestApplyEnvOverrides_TailscaleDataDir(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_TAILSCALE_DATADIR", "/custom/data")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Tailscale.DataDir != "/custom/data" {
+		t.Errorf("Tailscale.DataDir = %q, want %q", cfg.Tailscale.DataDir, "/custom/data")
+	}
+}
+
+func TestApplyEnvOverrides_ExistingMapEntry(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Tailscale.Providers["default"] = &TailscaleServerConfig{}
+
+	t.Setenv("TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTID", "my-client-id")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p := cfg.Tailscale.Providers["default"]
+	if p == nil {
+		t.Fatal("provider 'default' is nil")
+	}
+
+	if p.ClientID != "my-client-id" {
+		t.Errorf("ClientID = %q, want %q", p.ClientID, "my-client-id")
+	}
+}
+
+func TestApplyEnvOverrides_AutoCreateMapEntry(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_TAILSCALE_PROVIDERS_NEWPROV_CLIENTSECRET", "secret123")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p := cfg.Tailscale.Providers["newprov"]
+	if p == nil {
+		t.Fatal("provider 'newprov' was not auto-created")
+	}
+
+	if p.ClientSecret != "secret123" {
+		t.Errorf("ClientSecret = %q, want %q", p.ClientSecret, "secret123")
+	}
+
+	// Verify defaults were applied to the new entry.
+	if p.ControlURL != "https://controlplane.tailscale.com" {
+		t.Errorf("ControlURL = %q, want default", p.ControlURL)
+	}
+}
+
+func TestApplyEnvOverrides_DockerMapEntry(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_DOCKER_LOCAL_HOST", "tcp://1.2.3.4:2376")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	d := cfg.Docker["local"]
+	if d == nil {
+		t.Fatal("docker 'local' was not auto-created")
+	}
+
+	if d.Host != "tcp://1.2.3.4:2376" {
+		t.Errorf("Host = %q, want %q", d.Host, "tcp://1.2.3.4:2376")
+	}
+}
+
+func TestApplyEnvOverrides_MultiWordYAMLTag(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Docker["local"] = &DockerTargetProviderConfig{}
+
+	t.Setenv("TSDPROXY_DOCKER_LOCAL_TRYDOCKERINTERNALNETWORK", "true")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Docker["local"].TryDockerInternalNetwork != true {
+		t.Error("TryDockerInternalNetwork should be true")
+	}
+}
+
+func TestApplyEnvOverrides_MultipleEnvVars(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTID", "id1")
+	t.Setenv("TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_CLIENTSECRET", "secret1")
+	t.Setenv("TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_TAGS", "tag:web")
+	t.Setenv("TSDPROXY_LOG_LEVEL", "debug")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p := cfg.Tailscale.Providers["default"]
+	if p == nil {
+		t.Fatal("provider 'default' is nil")
+	}
+
+	if p.ClientID != "id1" {
+		t.Errorf("ClientID = %q, want %q", p.ClientID, "id1")
+	}
+
+	if p.ClientSecret != "secret1" {
+		t.Errorf("ClientSecret = %q, want %q", p.ClientSecret, "secret1")
+	}
+
+	if p.Tags != "tag:web" {
+		t.Errorf("Tags = %q, want %q", p.Tags, "tag:web")
+	}
+
+	if cfg.Log.Level != "debug" {
+		t.Errorf("Log.Level = %q, want %q", cfg.Log.Level, "debug")
+	}
+}
+
+func TestApplyEnvOverrides_LegacyEnvVarsSkipped(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_AUTHKEY", "should-be-ignored")
+	t.Setenv("TSDPROXY_AUTHKEYFILE", "should-be-ignored")
+	t.Setenv("TSDPROXY_CONTROLURL", "should-be-ignored")
+	t.Setenv("TSDPROXY_DATADIR", "should-be-ignored")
+	t.Setenv("TSDPROXY_HOSTNAME", "should-be-ignored")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyEnvOverrides_InvalidBool(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_PROXYACCESSLOG", "notabool")
+
+	err := applyEnvOverrides(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid bool value")
+	}
+}
+
+func TestApplyEnvOverrides_InvalidUint16(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_HTTP_PORT", "99999")
+
+	err := applyEnvOverrides(cfg)
+	if err == nil {
+		t.Fatal("expected error for out-of-range uint16 value")
+	}
+}
+
+func TestApplyEnvOverrides_UnknownPath(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_NONEXISTENT_FIELD", "value")
+
+	err := applyEnvOverrides(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown path")
+	}
+}
+
+func TestApplyEnvOverrides_TailscaleProviderControlURL(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_TAILSCALE_PROVIDERS_HEADSCALE_CONTROLURL", "http://headscale.local")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	p := cfg.Tailscale.Providers["headscale"]
+	if p == nil {
+		t.Fatal("provider 'headscale' was not auto-created")
+	}
+
+	if p.ControlURL != "http://headscale.local" {
+		t.Errorf("ControlURL = %q, want %q", p.ControlURL, "http://headscale.local")
+	}
+}
+
+func TestApplyEnvOverrides_HTTPHostname(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_HTTP_HOSTNAME", "127.0.0.1")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.HTTP.Hostname != "127.0.0.1" {
+		t.Errorf("HTTP.Hostname = %q, want %q", cfg.HTTP.Hostname, "127.0.0.1")
+	}
+}
+
+func TestApplyEnvOverrides_LogJSON(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("TSDPROXY_LOG_JSON", "true")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Log.JSON != true {
+		t.Error("Log.JSON should be true")
+	}
+}
+
+func TestApplyEnvOverrides_NonTSDPROXYIgnored(t *testing.T) {
+	cfg := newTestConfig(t)
+
+	t.Setenv("OTHER_VAR", "value")
+	t.Setenv("HOME", "/home/user")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplyEnvOverrides_DockerDefaultProxyProvider(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.Docker["remote"] = &DockerTargetProviderConfig{}
+
+	t.Setenv("TSDPROXY_DOCKER_REMOTE_DEFAULTPROXYPROVIDER", "server1")
+
+	if err := applyEnvOverrides(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Docker["remote"].DefaultProxyProvider != "server1" {
+		t.Errorf("DefaultProxyProvider = %q, want %q",
+			cfg.Docker["remote"].DefaultProxyProvider, "server1")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #256 — I've been using this on my NAS successfully with OAuth via env vars in Docker Compose.

Adds a general `TSDPROXY_*` environment variable override system so users can configure tsdproxy via env vars (e.g. in Docker Compose) without mounting a YAML config file. This allows OAuth credentials (`clientId`, `clientSecret`) and other sensitive settings to be supplied securely through environment variables instead of being committed to version control.

Naming convention: `TSDPROXY_<UPPERCASED_YAML_PATH>` with underscores between levels. Map fields (`docker`, `providers`) consume one segment as the map key, auto-creating entries with default values when the key doesn't exist. Multi-word yaml tags (e.g. `defaultProxyProvider`) are matched greedily without separators.

Legacy first-run env vars (`TSDPROXY_AUTHKEY`, `TSDPROXY_AUTHKEYFILE`, `TSDPROXY_CONTROLURL`, `TSDPROXY_DATADIR`, `TSDPROXY_HOSTNAME`) are excluded so the override system doesn't conflict with the existing `generateDefaultProviders` flow.

## Changes

- `internal/config/envoverride.go` — New env var override system that maps `TSDPROXY_*` env vars to config fields
- `internal/config/envoverride_test.go` — Tests for the env override system (19 cases)
- `internal/config/config.go` — Integrate env override into config loading (6-line hook after `defaults.Set`)
- `docs/content/docs/v2/serverconfig.md` — Document env var override usage
- `docs/content/docs/v2/advanced/tailscale.md` — Document Docker Compose with env-var OAuth credentials

## Test plan

- [x] Unit tests for env var override mapping (\`envoverride_test.go\`, 19 cases pass)
- [x] Verified OAuth flow works end-to-end on personal NAS deployment with credentials supplied entirely via \`TSDPROXY_TAILSCALE_PROVIDERS_DEFAULT_*\` env vars