### PR TITLE
feat(tailscale): auto-recover from stale tsnet state at runtime

### DIFF
--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -21,7 +21,8 @@ import (
 type (
 	// Proxy struct is a struct that contains all the information needed to run a proxy.
 	Proxy struct {
-		onUpdate func(event model.ProxyEvent)
+		onUpdate  func(event model.ProxyEvent)
+		onRestart func()
 
 		log           zerolog.Logger
 		ctx           context.Context
@@ -32,6 +33,7 @@ type (
 		ports         map[string]portHandler
 		mtx           sync.RWMutex
 		status        model.ProxyStatus
+		restartable   bool
 	}
 )
 
@@ -82,6 +84,19 @@ func (proxy *Proxy) Start() {
 	go func() {
 		for event := range proxy.providerProxy.WatchEvents() {
 			proxy.setStatus(event.Status)
+		}
+		// Events channel closed; if this isn't a normal shutdown, the provider
+		// proxy terminated unexpectedly (e.g. tsnet hit "invalid key" and cleaned
+		// stale state). Trigger a one-shot restart to recover.
+		status := proxy.GetStatus()
+		if status == model.ProxyStatusStopping || status == model.ProxyStatusStopped {
+			return
+		}
+		proxy.log.Warn().Msg("provider proxy terminated unexpectedly; attempting one-shot restart")
+		proxy.close()
+		if proxy.restartable && proxy.onRestart != nil {
+			proxy.restartable = false
+			go proxy.onRestart()
 		}
 	}()
 }

--- a/internal/proxymanager/proxy_restart_test.go
+++ b/internal/proxymanager/proxy_restart_test.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2026 Paulo Almeida <almeidapaulopt@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package proxymanager
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/almeidapaulopt/tsdproxy/internal/model"
+	"github.com/almeidapaulopt/tsdproxy/internal/proxyproviders"
+	"github.com/rs/zerolog"
+)
+
+// fakeProviderProxy is a minimal ProxyInterface for testing the restart logic.
+type fakeProviderProxy struct {
+	events chan model.ProxyEvent
+}
+
+var _ proxyproviders.ProxyInterface = (*fakeProviderProxy)(nil)
+
+func (f *fakeProviderProxy) Start(context.Context) error              { return nil }
+func (f *fakeProviderProxy) Close() error                             { return nil }
+func (f *fakeProviderProxy) GetListener(string) (net.Listener, error) { return nil, nil }
+func (f *fakeProviderProxy) GetURL() string                           { return "" }
+func (f *fakeProviderProxy) GetAuthURL() string                       { return "" }
+func (f *fakeProviderProxy) WatchEvents() chan model.ProxyEvent       { return f.events }
+func (f *fakeProviderProxy) Whois(*http.Request) model.Whois          { return model.Whois{} }
+
+func newTestProxy(restartable bool) (*Proxy, *fakeProviderProxy) {
+	events := make(chan model.ProxyEvent, 1)
+	fp := &fakeProviderProxy{events: events}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p := &Proxy{
+		log:           zerolog.Nop(),
+		Config:        &model.Config{Hostname: "test"},
+		ctx:           ctx,
+		cancel:        cancel,
+		providerProxy: fp,
+		ports:         make(map[string]portHandler),
+		restartable:   restartable,
+	}
+	return p, fp
+}
+
+func TestRestart_TriggersOnUnexpectedClose(t *testing.T) {
+	p, fp := newTestProxy(true)
+
+	var restartCount atomic.Int32
+	p.onRestart = func() {
+		restartCount.Add(1)
+	}
+
+	// Simulate the provider proxy sending an error then closing the channel,
+	// matching what watchStatus does on "invalid key" detection.
+	fp.events <- model.ProxyEvent{Status: model.ProxyStatusError}
+	close(fp.events)
+
+	// Start reads from the events channel in a goroutine.
+	p.Start()
+
+	// Wait for the restart goroutine to fire.
+	deadline := time.After(2 * time.Second)
+	for {
+		if restartCount.Load() > 0 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("onRestart was not called within timeout")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	if restartCount.Load() != 1 {
+		t.Errorf("expected exactly 1 restart, got %d", restartCount.Load())
+	}
+}
+
+func TestRestart_DoesNotTriggerWhenNotRestartable(t *testing.T) {
+	p, fp := newTestProxy(false)
+
+	var restartCalled atomic.Bool
+	p.onRestart = func() {
+		restartCalled.Store(true)
+	}
+
+	fp.events <- model.ProxyEvent{Status: model.ProxyStatusError}
+	close(fp.events)
+
+	p.Start()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if restartCalled.Load() {
+		t.Error("onRestart should not be called when restartable is false")
+	}
+}
+
+func TestRestart_DoesNotTriggerOnNormalShutdown(t *testing.T) {
+	p, fp := newTestProxy(true)
+
+	var restartCalled atomic.Bool
+	p.onRestart = func() {
+		restartCalled.Store(true)
+	}
+
+	// Simulate normal shutdown: status is set to Stopping before channel closes.
+	fp.events <- model.ProxyEvent{Status: model.ProxyStatusStopping}
+	close(fp.events)
+
+	p.Start()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if restartCalled.Load() {
+		t.Error("onRestart should not be called during normal shutdown")
+	}
+}

--- a/internal/proxymanager/proxymanager.go
+++ b/internal/proxymanager/proxymanager.go
@@ -298,7 +298,7 @@ func (pm *ProxyManager) eventStart(event targetproviders.TargetEvent) {
 		return
 	}
 
-	pm.newAndStartProxy(pcfg.Hostname, pcfg)
+	pm.newAndStartProxy(pcfg.Hostname, pcfg, true)
 }
 
 // eventStop method stops a Proxy from a event trigger
@@ -328,8 +328,11 @@ func (pm *ProxyManager) eventStop(event targetproviders.TargetEvent) {
 	}
 }
 
-// newAndStartProxy method creates a new proxy and starts it.
-func (pm *ProxyManager) newAndStartProxy(name string, proxyConfig *model.Config) {
+// newAndStartProxy method creates a new proxy and starts it. When restartable
+// is true, the proxy will automatically recover once from stale tsnet state
+// errors (e.g. after a container restart). The auto-restart spawns this
+// function again with restartable=false to avoid loops.
+func (pm *ProxyManager) newAndStartProxy(name string, proxyConfig *model.Config, restartable bool) {
 	pm.log.Debug().Str("proxy", name).Msg("Creating proxy")
 
 	proxyProvider, err := pm.getProxyProvider(proxyConfig)
@@ -347,6 +350,13 @@ func (pm *ProxyManager) newAndStartProxy(name string, proxyConfig *model.Config)
 	// any status change in proxy will be broadcasted
 	p.onUpdate = func(event model.ProxyEvent) {
 		pm.broadcastStatusEvents(event)
+	}
+
+	p.restartable = restartable
+	p.onRestart = func() {
+		pm.log.Info().Str("proxy", name).Msg("restarting proxy after unexpected termination")
+		pm.removeProxy(name)
+		pm.newAndStartProxy(name, proxyConfig, false)
 	}
 
 	pm.addProxy(p)

--- a/internal/proxyproviders/tailscale/proxy.go
+++ b/internal/proxyproviders/tailscale/proxy.go
@@ -106,6 +106,22 @@ func (p *Proxy) Close() error {
 	return err
 }
 
+// removeStaleState removes the entire tsnet data directory so the next start
+// gets clean state. Called when tsnet reports an "invalid key" error at runtime,
+// which indicates the on-disk state no longer matches what control-plane expects
+// (e.g. after a hard crash, ephemeral node expiry, or admin-side device deletion).
+func (p *Proxy) removeStaleState() {
+	if p.tsServer == nil || p.tsServer.Dir == "" {
+		return
+	}
+	dir := p.tsServer.Dir
+	if err := os.RemoveAll(dir); err != nil {
+		p.log.Error().Err(err).Str("path", dir).Msg("failed to remove stale tsnet state directory")
+		return
+	}
+	p.log.Info().Str("path", dir).Msg("removed stale tsnet state directory")
+}
+
 func (p *Proxy) GetListener(port string) (net.Listener, error) {
 	portCfg, ok := p.config.Ports[port]
 	if !ok {
@@ -197,6 +213,15 @@ func (p *Proxy) watchStatus() {
 						" hardware attestation (not supported by tsnet)." +
 						" Verify the key is correct and check tailnet policy settings.",
 				)
+				// Remove the data directory so the next start gets clean tsnet state and
+				// a fresh stateMeta; close the events channel to signal proxymanager to
+				// trigger a one-shot restart.
+				p.removeStaleState()
+				p.setStatus(model.ProxyStatusError, "", "")
+				p.closeOnce.Do(func() {
+					close(p.events)
+				})
+				return
 			}
 
 			p.setStatus(model.ProxyStatusError, "", "")

--- a/internal/proxyproviders/tailscale/proxy_test.go
+++ b/internal/proxyproviders/tailscale/proxy_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Paulo Almeida <almeidapaulopt@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"tailscale.com/tsnet"
+)
+
+func TestRemoveStaleState_RemovesDatadir(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "node-a")
+
+	// Create the datadir with the typical files inside.
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"tailscaled.state", "tsdproxy.yaml"} {
+		if err := os.WriteFile(filepath.Join(stateDir, name), []byte("stale"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	p := &Proxy{
+		log:      zerolog.Nop(),
+		tsServer: &tsnet.Server{Dir: stateDir},
+	}
+
+	p.removeStaleState()
+
+	if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+		t.Errorf("datadir %s should have been removed, got err: %v", stateDir, err)
+	}
+}
+
+func TestRemoveStaleState_HandlesMissingDatadir(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist")
+
+	p := &Proxy{
+		log:      zerolog.Nop(),
+		tsServer: &tsnet.Server{Dir: missing},
+	}
+
+	// Should not panic or error when datadir doesn't exist.
+	p.removeStaleState()
+}
+
+func TestRemoveStaleState_NoTSServer(t *testing.T) {
+	p := &Proxy{
+		log: zerolog.Nop(),
+	}
+
+	// Should be a no-op (no panic) when tsServer is nil.
+	p.removeStaleState()
+}
+
+func TestRemoveStaleState_EmptyDir(t *testing.T) {
+	p := &Proxy{
+		log:      zerolog.Nop(),
+		tsServer: &tsnet.Server{Dir: ""},
+	}
+
+	// Should be a no-op (not blow away cwd or root).
+	p.removeStaleState()
+}


### PR DESCRIPTION
## Summary

Layers runtime auto-recovery on top of the existing preventive cleanup in `cleanStaleState`. Today, if tsnet's backend reports `"invalid key"` while the proxy is already running, the proxy gets stuck in `ProxyStatusError` until a human notices and either restarts tsdproxy or manually deletes the data directory.

`cleanStaleState` (added in `d4a2e3c`) only runs at `NewProxy` time and only triggers on ephemeral flag mismatch, so it doesn't cover these runtime failure modes:

- Hard crash / OOM / `docker kill -9` before `Close()`'s ephemeral cleanup runs, leaving stale `tailscaled.state`
- Host power loss with ephemeral node expiry on the tailnet side
- Manual device deletion in the Tailscale admin console while tsdproxy is running
- Control-plane revocation for any reason

After this change, those scenarios trigger a single automatic `RemoveAll(datadir) + restart` cycle. If the restart also fails, the proxy stops in `ProxyStatusError` (no infinite loop).

## Changes

- `tailscale/proxy.go`: when `watchStatus` sees `"invalid key"`, `os.RemoveAll` the tsnet data directory (mirroring `cleanStaleState`'s approach), set `ProxyStatusError`, and close the events channel so `proxymanager` can detect the unexpected termination.
- `proxymanager/proxy.go`: when the events channel closes outside of a normal `Stopping`/`Stopped` flow, log and trigger a one-shot `onRestart` callback. The `restartable` flag is consumed (set to false) on first use to prevent restart loops.
- `proxymanager/proxymanager.go`: `newAndStartProxy` now takes a `restartable` parameter. `eventStart` passes `true`; the auto-recovery path passes `false` when re-spawning, so a persistently-failing proxy can't loop.

## Loop-prevention contract

`restartable` is consumed exactly once, before `onRestart` is called. The recursive `newAndStartProxy(name, proxyConfig, false)` ensures the second proxy instance has `restartable=false`, so if it also hits `"invalid key"`, the channel close triggers the unexpected-termination logging but no further restart. The proxy ends in `ProxyStatusError` and surfaces normally on the dashboard.

## Test plan

- [x] `proxyproviders/tailscale/proxy_test.go` — 4 cases: `removeStaleState` removes the datadir, handles missing/empty/nil cases without panic
- [x] `proxymanager/proxy_restart_test.go` — 3 cases: restart fires on unexpected close, doesn't fire when `restartable=false`, doesn't fire on normal `Stopping` shutdown
- [x] All 7 unit tests pass locally
- [x] `go vet` clean across both modified packages
- [x] Validated end-to-end on personal NAS deployment by force-killing the container mid-run; on next start the proxy auto-recovered exactly once. After the recovery, normal traffic flowed without intervention.

## Related

Builds on top of `d4a2e3c` (preventive cleanup of tsnet state on ephemeral flag change). Complementary, not overlapping — that change prevents stale state at config-change time; this change recovers from stale state at runtime when prevention wasn't possible.

Tracked separately from #384 (env var overrides) to keep scopes small.