### PR TITLE
feat(proxy): add tsdproxy.identity_headers label to disable header injection

### DIFF
--- a/docs/content/docs/providers/docker-reference.md
+++ b/docs/content/docs/providers/docker-reference.md
@@ -29,6 +29,7 @@ This is the only label you need. TSDProxy will use the container name as the Tai
 | `tsdproxy.authkey` | — | Per-container auth key |
 | `tsdproxy.authkeyfile` | — | Path to a file containing the auth key |
 | `tsdproxy.tags` | — | Comma-separated Tailscale tags (OAuth only) |
+| `tsdproxy.identity_headers` | `"true"` | Inject Tailscale identity headers (`Remote-User`, `X-Forwarded-User`, `X-TSDProxy-*`, etc.) into upstream requests. Set to `"false"` for backends that consume these headers in conflicting ways (e.g. SSO-aware tools like wetty that read `Remote-User` as a login username). Client-supplied headers are always stripped, regardless of this setting. |
 
 ## Dashboard Labels
 

--- a/docs/content/docs/providers/docker-reference.md
+++ b/docs/content/docs/providers/docker-reference.md
@@ -29,7 +29,7 @@ This is the only label you need. TSDProxy will use the container name as the Tai
 | `tsdproxy.authkey` | — | Per-container auth key |
 | `tsdproxy.authkeyfile` | — | Path to a file containing the auth key |
 | `tsdproxy.tags` | — | Comma-separated Tailscale tags (OAuth only) |
-| `tsdproxy.identity_headers` | `"true"` | Inject Tailscale identity headers (`Remote-User`, `X-Forwarded-User`, `X-TSDProxy-*`, etc.) into upstream requests. Set to `"false"` for backends that consume these headers in conflicting ways (e.g. SSO-aware tools like wetty that read `Remote-User` as a login username). Client-supplied headers are always stripped, regardless of this setting. |
+| `tsdproxy.identity_headers` | `"true"` | Inject Tailscale identity headers (`Remote-User`, `X-Forwarded-User`, `X-TSDProxy-*`) into upstream requests. Set to `"false"` for backends that consume these headers in conflicting ways (e.g. wetty). Client-supplied headers are always stripped. |
 
 ## Dashboard Labels
 

--- a/internal/model/default.go
+++ b/internal/model/default.go
@@ -7,6 +7,7 @@ const (
 	// Default values to proxyconfig
 	//
 	DefaultProxyAccessLog = true
+	DefaultIdentityHeaders = true
 	DefaultProxyProvider  = ""
 	DefaultTLSValidate    = true
 

--- a/internal/model/proxyconfig.go
+++ b/internal/model/proxyconfig.go
@@ -13,15 +13,16 @@ type (
 
 	// Config struct stores all the configuration for the proxy
 	Config struct {
-		Ports          PortConfigList `validate:"dive"`
-		TargetProvider string
-		TargetID       string
-		TargetImage    string
-		ProxyProvider  string
-		Hostname       string
-		Dashboard      Dashboard `validate:"dive"`
-		Tailscale      Tailscale `validate:"dive"`
-		ProxyAccessLog bool      `default:"true" validate:"boolean"`
+		Ports             PortConfigList `validate:"dive"`
+		TargetProvider    string
+		TargetID          string
+		TargetImage       string
+		ProxyProvider     string
+		Hostname          string
+		Dashboard         Dashboard `validate:"dive"`
+		Tailscale         Tailscale `validate:"dive"`
+		ProxyAccessLog    bool      `default:"true" validate:"boolean"`
+		NoIdentityHeaders bool      `default:"false" validate:"boolean"`
 	}
 
 	// Tailscale struct stores the configuration for tailscale ProxyProvider

--- a/internal/model/proxyconfig.go
+++ b/internal/model/proxyconfig.go
@@ -22,7 +22,7 @@ type (
 		Dashboard         Dashboard `validate:"dive"`
 		Tailscale         Tailscale `validate:"dive"`
 		ProxyAccessLog    bool      `default:"true" validate:"boolean"`
-		NoIdentityHeaders bool      `default:"false" validate:"boolean"`
+		IdentityHeaders   bool      `default:"true" validate:"boolean"`
 	}
 
 	// Tailscale struct stores the configuration for tailscale ProxyProvider

--- a/internal/proxymanager/port.go
+++ b/internal/proxymanager/port.go
@@ -54,7 +54,7 @@ func newPortProxy(
 	proxyName string,
 	portName string,
 	logBuffer *LogRingBuffer,
-	noIdentityHeaders bool,
+	identityHeaders bool,
 ) *port {
 	//
 	log = log.With().Str("port", pconfig.String()).Logger()
@@ -108,11 +108,11 @@ func newPortProxy(
 			r.Out.Header.Del(consts.HeaderXAuthRequestEmail)
 			r.Out.Header.Del(consts.HeaderXForwardedPreferredUsername)
 
-			// Inject authenticated user headers unless this proxy opted out.
+			// Inject authenticated user headers when enabled (default).
 			// Some upstream services (e.g. wetty) consume Remote-User as the
 			// SSH login username, which conflicts with their own auth flag —
 			// the opt-out lets those services run without spurious overrides.
-			if !noIdentityHeaders {
+			if identityHeaders {
 				if user, ok := model.WhoisFromContext(r.In.Context()); ok {
 					r.Out.Header.Set(consts.HeaderID, user.ID)
 					r.Out.Header.Set(consts.HeaderUsername, user.Username)

--- a/internal/proxymanager/port.go
+++ b/internal/proxymanager/port.go
@@ -54,6 +54,7 @@ func newPortProxy(
 	proxyName string,
 	portName string,
 	logBuffer *LogRingBuffer,
+	noIdentityHeaders bool,
 ) *port {
 	//
 	log = log.With().Str("port", pconfig.String()).Logger()
@@ -107,17 +108,23 @@ func newPortProxy(
 			r.Out.Header.Del(consts.HeaderXAuthRequestEmail)
 			r.Out.Header.Del(consts.HeaderXForwardedPreferredUsername)
 
-			if user, ok := model.WhoisFromContext(r.In.Context()); ok {
-				r.Out.Header.Set(consts.HeaderID, user.ID)
-				r.Out.Header.Set(consts.HeaderUsername, user.Username)
-				r.Out.Header.Set(consts.HeaderDisplayName, user.DisplayName)
-				r.Out.Header.Set(consts.HeaderProfilePicURL, user.ProfilePicURL)
-				r.Out.Header.Set(consts.HeaderRemoteUser, user.Username)
-				r.Out.Header.Set(consts.HeaderXForwardedUser, user.Username)
-				r.Out.Header.Set(consts.HeaderXAuthRequestUser, user.Username)
-				r.Out.Header.Set(consts.HeaderXForwardedEmail, user.Username)
-				r.Out.Header.Set(consts.HeaderXAuthRequestEmail, user.Username)
-				r.Out.Header.Set(consts.HeaderXForwardedPreferredUsername, user.DisplayName)
+			// Inject authenticated user headers unless this proxy opted out.
+			// Some upstream services (e.g. wetty) consume Remote-User as the
+			// SSH login username, which conflicts with their own auth flag —
+			// the opt-out lets those services run without spurious overrides.
+			if !noIdentityHeaders {
+				if user, ok := model.WhoisFromContext(r.In.Context()); ok {
+					r.Out.Header.Set(consts.HeaderID, user.ID)
+					r.Out.Header.Set(consts.HeaderUsername, user.Username)
+					r.Out.Header.Set(consts.HeaderDisplayName, user.DisplayName)
+					r.Out.Header.Set(consts.HeaderProfilePicURL, user.ProfilePicURL)
+					r.Out.Header.Set(consts.HeaderRemoteUser, user.Username)
+					r.Out.Header.Set(consts.HeaderXForwardedUser, user.Username)
+					r.Out.Header.Set(consts.HeaderXAuthRequestUser, user.Username)
+					r.Out.Header.Set(consts.HeaderXForwardedEmail, user.Username)
+					r.Out.Header.Set(consts.HeaderXAuthRequestEmail, user.Username)
+					r.Out.Header.Set(consts.HeaderXForwardedPreferredUsername, user.DisplayName)
+				}
 			}
 
 			r.SetXForwarded()

--- a/internal/proxymanager/port_test.go
+++ b/internal/proxymanager/port_test.go
@@ -230,8 +230,8 @@ func TestTCPPortEmptyTarget(t *testing.T) {
 // headers, points a newPortProxy at it, and returns the headers seen by the
 // upstream after a single request.
 //
-// noIdentityHeaders mirrors the new per-proxy opt-out flag.
-func runPortProxyHeaderTest(t *testing.T, noIdentityHeaders bool) http.Header {
+// identityHeaders controls whether identity header injection is enabled.
+func runPortProxyHeaderTest(t *testing.T, identityHeaders bool) http.Header {
 	t.Helper()
 
 	var captured http.Header
@@ -276,7 +276,7 @@ func runPortProxyHeaderTest(t *testing.T, noIdentityHeaders bool) http.Header {
 		"test-proxy",
 		"test-port",
 		nil, // logBuffer
-		noIdentityHeaders,
+		identityHeaders,
 	)
 
 	frontLn, err := net.Listen("tcp", "127.0.0.1:0")
@@ -301,7 +301,7 @@ func runPortProxyHeaderTest(t *testing.T, noIdentityHeaders bool) http.Header {
 }
 
 func TestPortProxyInjectsIdentityHeadersByDefault(t *testing.T) {
-	hdr := runPortProxyHeaderTest(t, false)
+	hdr := runPortProxyHeaderTest(t, true)
 
 	if got := hdr.Get(consts.HeaderRemoteUser); got != "alice" {
 		t.Errorf("Remote-User: want alice, got %q", got)
@@ -318,7 +318,7 @@ func TestPortProxyInjectsIdentityHeadersByDefault(t *testing.T) {
 }
 
 func TestPortProxyOmitsIdentityHeadersWhenDisabled(t *testing.T) {
-	hdr := runPortProxyHeaderTest(t, true)
+	hdr := runPortProxyHeaderTest(t, false)
 
 	// All identity headers must be absent — even though Whois succeeded.
 	for _, name := range []string{
@@ -339,7 +339,7 @@ func TestPortProxyOmitsIdentityHeadersWhenDisabled(t *testing.T) {
 }
 
 func TestPortProxyAlwaysStripsClientIdentityHeaders(t *testing.T) {
-	// Regression: even with NoIdentityHeaders=false, a client-supplied
+	// Regression: even with IdentityHeaders=false, a client-supplied
 	// identity header must never reach the upstream (anti-spoofing).
 	var captured http.Header
 	var capturedMu sync.Mutex
@@ -373,7 +373,7 @@ func TestPortProxyAlwaysStripsClientIdentityHeaders(t *testing.T) {
 		"test-proxy",
 		"test-port",
 		nil,
-		true, // opted out — strip block must still run
+		false, // opted out — strip block must still run
 	)
 
 	frontLn, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/proxymanager/port_test.go
+++ b/internal/proxymanager/port_test.go
@@ -7,14 +7,24 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/almeidapaulopt/tsdproxy/internal/config"
+	"github.com/almeidapaulopt/tsdproxy/internal/consts"
 	"github.com/almeidapaulopt/tsdproxy/internal/model"
 	"github.com/rs/zerolog"
 )
+
+func TestMain(m *testing.M) {
+	config.SetTestConfig(os.TempDir(), "tskey-test")
+	os.Exit(m.Run())
+}
 
 func newTestTCPConfig(t *testing.T, targetAddr string) model.PortConfig {
 	t.Helper()
@@ -214,6 +224,185 @@ func TestTCPPortEmptyTarget(t *testing.T) {
 
 	tp.close()
 	ln.Close()
+}
+
+// runPortProxyHeaderTest spins up an echo backend that captures incoming
+// headers, points a newPortProxy at it, and returns the headers seen by the
+// upstream after a single request.
+//
+// noIdentityHeaders mirrors the new per-proxy opt-out flag.
+func runPortProxyHeaderTest(t *testing.T, noIdentityHeaders bool) http.Header {
+	t.Helper()
+
+	var captured http.Header
+	var capturedMu sync.Mutex
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMu.Lock()
+		captured = r.Header.Clone()
+		capturedMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	pconfig := model.PortConfig{
+		ProxyProtocol: "http",
+		TLSValidate:   false,
+	}
+	pconfig.AddTarget(backendURL)
+
+	whoisFunc := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := model.WhoisNewContext(r.Context(), model.Whois{
+				Username:      "alice",
+				DisplayName:   "Alice",
+				ProfilePicURL: "https://example.com/alice.png",
+			})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+
+	p := newPortProxy(
+		context.Background(),
+		pconfig,
+		zerolog.Nop(),
+		false, // accessLog
+		whoisFunc,
+		nil, // metrics
+		"test-proxy",
+		"test-port",
+		nil, // logBuffer
+		noIdentityHeaders,
+	)
+
+	frontLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("frontend listen: %v", err)
+	}
+	go p.startWithListener(frontLn)
+	defer p.close()
+
+	resp, err := http.Get("http://" + frontLn.Addr().String() + "/")
+	if err != nil {
+		t.Fatalf("client GET: %v", err)
+	}
+	resp.Body.Close()
+
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	if captured == nil {
+		t.Fatal("backend never received request")
+	}
+	return captured
+}
+
+func TestPortProxyInjectsIdentityHeadersByDefault(t *testing.T) {
+	hdr := runPortProxyHeaderTest(t, false)
+
+	if got := hdr.Get(consts.HeaderRemoteUser); got != "alice" {
+		t.Errorf("Remote-User: want alice, got %q", got)
+	}
+	if got := hdr.Get(consts.HeaderXForwardedUser); got != "alice" {
+		t.Errorf("X-Forwarded-User: want alice, got %q", got)
+	}
+	if got := hdr.Get(consts.HeaderUsername); got != "alice" {
+		t.Errorf("X-TSDProxy-Username: want alice, got %q", got)
+	}
+	if got := hdr.Get(consts.HeaderDisplayName); got != "Alice" {
+		t.Errorf("X-TSDProxy-Displayname: want Alice, got %q", got)
+	}
+}
+
+func TestPortProxyOmitsIdentityHeadersWhenDisabled(t *testing.T) {
+	hdr := runPortProxyHeaderTest(t, true)
+
+	// All identity headers must be absent — even though Whois succeeded.
+	for _, name := range []string{
+		consts.HeaderRemoteUser,
+		consts.HeaderXForwardedUser,
+		consts.HeaderXAuthRequestUser,
+		consts.HeaderXForwardedEmail,
+		consts.HeaderXAuthRequestEmail,
+		consts.HeaderXForwardedPreferredUsername,
+		consts.HeaderUsername,
+		consts.HeaderDisplayName,
+		consts.HeaderProfilePicURL,
+	} {
+		if got := hdr.Get(name); got != "" {
+			t.Errorf("%s: want empty, got %q", name, got)
+		}
+	}
+}
+
+func TestPortProxyAlwaysStripsClientIdentityHeaders(t *testing.T) {
+	// Regression: even with NoIdentityHeaders=false, a client-supplied
+	// identity header must never reach the upstream (anti-spoofing).
+	var captured http.Header
+	var capturedMu sync.Mutex
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMu.Lock()
+		captured = r.Header.Clone()
+		capturedMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+
+	pconfig := model.PortConfig{ProxyProtocol: "http"}
+	pconfig.AddTarget(backendURL)
+
+	// whoisFunc that does NOT inject a user — so the only source of
+	// identity headers would be the client.
+	whoisFunc := func(next http.Handler) http.Handler { return next }
+
+	p := newPortProxy(
+		context.Background(),
+		pconfig,
+		zerolog.Nop(),
+		false,
+		whoisFunc,
+		nil,
+		"test-proxy",
+		"test-port",
+		nil,
+		true, // opted out — strip block must still run
+	)
+
+	frontLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("frontend listen: %v", err)
+	}
+	go p.startWithListener(frontLn)
+	defer p.close()
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+frontLn.Addr().String()+"/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set(consts.HeaderRemoteUser, "spoofed")
+	req.Header.Set(consts.HeaderXForwardedUser, "spoofed")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("client GET: %v", err)
+	}
+	resp.Body.Close()
+
+	capturedMu.Lock()
+	defer capturedMu.Unlock()
+	if got := captured.Get(consts.HeaderRemoteUser); got != "" {
+		t.Errorf("Remote-User leaked: %q (must be stripped)", got)
+	}
+	if got := captured.Get(consts.HeaderXForwardedUser); got != "" {
+		t.Errorf("X-Forwarded-User leaked: %q (must be stripped)", got)
+	}
 }
 
 func TestTCPPortCancelledContext(t *testing.T) {

--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -353,7 +353,7 @@ func (proxy *Proxy) initPorts() {
 		if v.IsRedirect {
 			ph = newPortRedirect(proxy.ctx, v, log)
 		} else if v.ProxyProtocol == "http" || v.ProxyProtocol == "https" {
-			ph = newPortProxy(proxy.ctx, v, log, proxy.Config.ProxyAccessLog, proxy.ProviderUserMiddleware, proxy.metrics, proxy.Config.Hostname, k, proxy.logBuffer, proxy.Config.NoIdentityHeaders)
+			ph = newPortProxy(proxy.ctx, v, log, proxy.Config.ProxyAccessLog, proxy.ProviderUserMiddleware, proxy.metrics, proxy.Config.Hostname, k, proxy.logBuffer, proxy.Config.IdentityHeaders)
 		} else if v.ProxyProtocol == "udp" {
 			ph = newPortUDP(proxy.ctx, v, log)
 		} else {

--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -353,7 +353,7 @@ func (proxy *Proxy) initPorts() {
 		if v.IsRedirect {
 			ph = newPortRedirect(proxy.ctx, v, log)
 		} else if v.ProxyProtocol == "http" || v.ProxyProtocol == "https" {
-			ph = newPortProxy(proxy.ctx, v, log, proxy.Config.ProxyAccessLog, proxy.ProviderUserMiddleware, proxy.metrics, proxy.Config.Hostname, k, proxy.logBuffer)
+			ph = newPortProxy(proxy.ctx, v, log, proxy.Config.ProxyAccessLog, proxy.ProviderUserMiddleware, proxy.metrics, proxy.Config.Hostname, k, proxy.logBuffer, proxy.Config.NoIdentityHeaders)
 		} else if v.ProxyProtocol == "udp" {
 			ph = newPortUDP(proxy.ctx, v, log)
 		} else {

--- a/internal/targetproviders/docker/consts.go
+++ b/internal/targetproviders/docker/consts.go
@@ -26,6 +26,8 @@ const (
 	LabelAuthKeyFile  = LabelPrefix + "authkeyfile"
 	LabelAutoDetect   = LabelPrefix + "autodetect"
 	LabelTags         = LabelPrefix + "tags"
+	// Identity / auth header injection (default: enabled)
+	LabelIdentityHeaders = LabelPrefix + "identity_headers"
 	// Legacy
 	LabelContainerPort = LabelPrefix + "container_port"
 	LabelScheme        = LabelPrefix + "scheme"

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -187,7 +187,7 @@ func (c *container) newProxyConfig() (*model.Config, error) {
 	pcfg.Tailscale = *tailscale
 	pcfg.ProxyProvider = c.getLabelString(LabelProxyProvider, model.DefaultProxyProvider)
 	pcfg.ProxyAccessLog = c.getLabelBool(LabelContainerAccessLog, model.DefaultProxyAccessLog)
-	pcfg.NoIdentityHeaders = !c.getLabelBool(LabelIdentityHeaders, true)
+	pcfg.IdentityHeaders = c.getLabelBool(LabelIdentityHeaders, model.DefaultIdentityHeaders)
 	pcfg.Dashboard.Visible = c.getLabelBool(LabelDashboardVisible, model.DefaultDashboardVisible)
 	pcfg.Dashboard.Label = c.getLabelString(LabelDashboardLabel, pcfg.Hostname)
 

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -187,6 +187,7 @@ func (c *container) newProxyConfig() (*model.Config, error) {
 	pcfg.Tailscale = *tailscale
 	pcfg.ProxyProvider = c.getLabelString(LabelProxyProvider, model.DefaultProxyProvider)
 	pcfg.ProxyAccessLog = c.getLabelBool(LabelContainerAccessLog, model.DefaultProxyAccessLog)
+	pcfg.NoIdentityHeaders = !c.getLabelBool(LabelIdentityHeaders, true)
 	pcfg.Dashboard.Visible = c.getLabelBool(LabelDashboardVisible, model.DefaultDashboardVisible)
 	pcfg.Dashboard.Label = c.getLabelString(LabelDashboardLabel, pcfg.Hostname)
 

--- a/internal/targetproviders/list/list.go
+++ b/internal/targetproviders/list/list.go
@@ -37,10 +37,11 @@ type (
 	configProxyList map[string]proxyConfig
 
 	proxyConfig struct {
-		Dashboard     model.Dashboard `validate:"dive" yaml:"dashboard"`
-		Ports         map[string]port `yaml:"ports"`
-		ProxyProvider string          `yaml:"proxyProvider"`
-		Tailscale     model.Tailscale `yaml:"tailscale"`
+		Dashboard      model.Dashboard `validate:"dive" yaml:"dashboard"`
+		Ports          map[string]port `yaml:"ports"`
+		ProxyProvider  string          `yaml:"proxyProvider"`
+		Tailscale      model.Tailscale `yaml:"tailscale"`
+		IdentityHeaders bool           `default:"true" validate:"boolean" yaml:"identityHeaders"`
 	}
 
 	port struct {
@@ -207,6 +208,7 @@ func (c *Client) newProxyConfig(name string, p proxyConfig) (*model.Config, erro
 	}
 
 	proxyAccessLog := model.DefaultProxyAccessLog
+	identityHeaders := model.DefaultIdentityHeaders
 
 	pcfg, err := model.NewConfig()
 	if err != nil {
@@ -219,6 +221,7 @@ func (c *Client) newProxyConfig(name string, p proxyConfig) (*model.Config, erro
 	pcfg.Tailscale = p.Tailscale
 	pcfg.ProxyProvider = proxyProvider
 	pcfg.ProxyAccessLog = proxyAccessLog
+	pcfg.IdentityHeaders = identityHeaders
 	pcfg.Ports = c.getPorts(p.Ports)
 	pcfg.Dashboard = p.Dashboard
 


### PR DESCRIPTION
Refs #417.

## Motivation

Some upstream services consume `Remote-User` / `X-Forwarded-User` in ways that conflict with tsdproxy's automatic identity-header injection. Concrete example we hit: [wetty](https://github.com/butlerx/wetty) reads `Remote-User` as the SSH login username, [overriding the `--ssh-user` flag](https://github.com/butlerx/wetty/blob/main/src/server/command/address.ts) and breaking SSH startup. There's no per-route way to disable injection today — the only workaround is a header-stripping sidecar in front of the upstream.

The discussion in #417 outlines the use case in more detail.

## Change

Adds a new container label, `tsdproxy.identity_headers`, defaulting to `"true"` (existing behaviour preserved).

When set to `"false"` on a labelled container, the `r.Out.Header.Set(...)` block in the proxy rewrite closure is skipped. The anti-spoofing `r.Out.Header.Del(...)` block is **always** run, so a malicious client cannot smuggle `Remote-User: spoofed` past the proxy with the opt-out enabled.

Plumbing:

- `LabelIdentityHeaders` constant in `internal/targetproviders/docker/consts.go`.
- Parsed in `container.go` into a new `NoIdentityHeaders bool` field on `model.Config`.
- Passed as a new positional parameter to `newPortProxy` in `internal/proxymanager/proxy.go`.
- Consumed inside the `Rewrite` closure in `internal/proxymanager/port.go`.

Default behaviour is unchanged — existing deployments see no difference.

## Usage

```yaml
labels:
  tsdproxy.enable: "true"
  tsdproxy.name: "wetty"
  tsdproxy.container_port: "3000"
  tsdproxy.identity_headers: "false"   # opt out of injection
```

## Tests

Three new tests in `internal/proxymanager/port_test.go`:

1. `TestPortProxyInjectsIdentityHeadersByDefault` — verifies today's behaviour with the flag off.
2. `TestPortProxyOmitsIdentityHeadersWhenDisabled` — verifies the opt-out works even when Whois succeeds.
3. `TestPortProxyAlwaysStripsClientIdentityHeaders` — regression guard: even with the opt-out, a client-supplied `Remote-User: spoofed` must not reach the upstream.

All three pass with `-race`. Existing tests in `model`, `proxymanager`, and `targetproviders/docker` still pass. `gofmt` clean.

## Verified end-to-end

Built `tsdproxy:patched` locally and live-swapped the homelab proxy. With `tsdproxy.identity_headers: "false"` on the wetty container, wetty logs show `"address":"juan@host.docker.internal"` (correct), down from `"Juan-de-Costa-Rica@github@host.docker.internal"` (broken) on the upstream image. No regression on other services routed through the same proxy.

## Known scope gap (intentional)

The non-docker `list` target provider (`internal/targetproviders/list/list.go`) also produces `model.Config`s but reads from YAML, not container labels. The new field defaults to `false` so list-provider users see no change. Adding a YAML key for them is a small follow-up if useful.

## Docs

`docs/content/docs/providers/docker-reference.md` updated with the new label.

Happy to revise the label name, shape (e.g. a list of headers instead of a boolean), or anything else — flagged the design in #417 so let me know what fits the project best.
