### PR TITLE
feat: add port range support for UDP/TCP proxying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ build/all:
 ## run: run the  application
 .PHONY: run
 run: build/all
-	./tmp/${BINARY_NAME}
+	./tmp/${BINARY_NAME} -config dev/tsdproxy-local.yaml
 
 
 ## dev: start dev server

--- a/dev/docker-compose-local.yaml
+++ b/dev/docker-compose-local.yaml
@@ -67,6 +67,18 @@ services:
       - tsdproxy.dash.label=Standalone App
       - tsdproxy.dash.icon=mdi/application
 
+  udprange:
+    image: nginx:alpine
+    ports:
+      - 85:80
+      - 56000-56002:56000-56002/udp
+    labels:
+      - tsdproxy.enable=true
+      - tsdproxy.name=udprange
+      - tsdproxy.dash.label=UDP Range Test
+      - tsdproxy.port.1=443/https:80/http
+      - tsdproxy.port.2=56000-56002/udp:56000-56002/udp
+
 volumes:
   tsdata:
   tmp:

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -53,6 +53,19 @@ services:
     labels:
       - tsdproxy.enable=true
 
+  c4:
+    image: nginx
+    ports:
+      - 84:80
+      - 56000-56002:56000-56002/udp
+    networks:
+      c4:
+    labels:
+      - tsdproxy.enable=true
+      - tsdproxy.name=udprange
+      - tsdproxy.port.1=443/https:80/http
+      - tsdproxy.port.2=56000-56002/udp:56000-56002/udp
+
 volumes:
   tsdata:
   tmp:
@@ -69,3 +82,5 @@ networks:
     name: c2
   c3:
     name: c3
+  c4:
+    name: c4

--- a/dev/file1.yaml
+++ b/dev/file1.yaml
@@ -3,6 +3,13 @@ dash-dev:
     "443/https":
       targets:
         - "http://localhost:8080"
+udprange-list:
+  ports:
+    "56000-56002/udp":
+      tailscale:
+        funnel: true
+      targets:
+        - "udp://172.31.0.1:56000"
 # nas12:
 #   ports:
 #     "443/https":

--- a/internal/model/port.go
+++ b/internal/model/port.go
@@ -41,8 +41,10 @@ var (
 )
 
 const (
-	minPort = 1
-	maxPort = 65535
+	minPort     = 1
+	maxPort     = 65535
+	rangeSep    = "-"
+	maxRangeLen = 1000
 )
 
 // validatePortRange checks that a port number is within the valid range.
@@ -162,6 +164,17 @@ func parseProxySegment(segment string, config *PortConfig) error {
 	return nil
 }
 
+func defaultTargetProtocol(proxyProtocol string) string {
+	switch proxyProtocol {
+	case "tcp":
+		return "tcp"
+	case "udp":
+		return "udp"
+	default:
+		return "http"
+	}
+}
+
 func parseTargetSegment(segment string, config *PortConfig) error {
 	targetParts := strings.Split(segment, protocolSeparator)
 	if len(targetParts) > 2 { //nolint:mnd
@@ -176,20 +189,7 @@ func parseTargetSegment(segment string, config *PortConfig) error {
 		return fmt.Errorf("invalid target port: %w", err)
 	}
 
-	// Default target protocol to match the proxy protocol for non-HTTP schemes.
-	// This ensures that a TCP proxy (e.g. "8222/tcp:22") gets a "tcp" target
-	// rather than "http", which would cause the target URL to be routed
-	// incorrectly through Docker's HTTP-aware port mapping.
-	//
-	// NOTE: This reads config.ProxyProtocol, which is set by parseProxySegment.
-	// parseProxySegment MUST run before this function. The coupling is safe
-	// because NewPortLongLabel calls them in that order.
-	targetProtocol := "http"
-	if config.ProxyProtocol == "tcp" {
-		targetProtocol = "tcp"
-	} else if config.ProxyProtocol == "udp" {
-		targetProtocol = "udp"
-	}
+	targetProtocol := defaultTargetProtocol(config.ProxyProtocol)
 
 	if len(targetParts) == 2 { //nolint:mnd
 		targetProtocol = targetParts[1]
@@ -239,4 +239,242 @@ func (p *PortConfig) ReplaceTarget(origin, target *url.URL) {
 			p.targets[k] = target
 		}
 	}
+}
+
+// isPortRange checks whether a port string contains a range expression (e.g., "56000-56100").
+func isPortRange(s string) bool {
+	parts := strings.SplitN(s, rangeSep, 2)
+	if len(parts) != 2 {
+		return false
+	}
+	_, err1 := strconv.Atoi(parts[0])
+	_, err2 := strconv.Atoi(parts[1])
+	return err1 == nil && err2 == nil
+}
+
+// parsePortRange parses a port range string like "56000-56100" and returns the start and end ports.
+func parsePortRange(s string) (start, end int, err error) {
+	parts := strings.SplitN(s, rangeSep, 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid port range %q: expected format start-end", s)
+	}
+
+	start, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid port range start %q: %w", parts[0], err)
+	}
+
+	end, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid port range end %q: %w", parts[1], err)
+	}
+
+	if err := validatePortRange(start); err != nil {
+		return 0, 0, fmt.Errorf("invalid port range start: %w", err)
+	}
+	if err := validatePortRange(end); err != nil {
+		return 0, 0, fmt.Errorf("invalid port range end: %w", err)
+	}
+
+	if start > end {
+		return 0, 0, fmt.Errorf("invalid port range %q: start %d is greater than end %d", s, start, end)
+	}
+
+	count := end - start + 1
+	if count > maxRangeLen {
+		return 0, 0, fmt.Errorf("port range %q too large: %d ports (max %d)", s, count, maxRangeLen)
+	}
+
+	return start, end, nil
+}
+
+// IsPortRangeLabel checks whether a port configuration string uses range syntax
+// in either the proxy or target segment (or both).
+func IsPortRangeLabel(s string) bool {
+	separator := detectSeparator(s)
+	parts := strings.Split(s, separator)
+	if len(parts) != 2 { //nolint:mnd
+		return false
+	}
+
+	proxyPort := strings.SplitN(parts[0], protocolSeparator, 2)[0]
+	if isPortRange(proxyPort) {
+		return true
+	}
+
+	if separator != redirectSeparator {
+		targetPort := strings.SplitN(parts[1], protocolSeparator, 2)[0]
+		return isPortRange(targetPort)
+	}
+
+	return false
+}
+
+// ExpandPortRangeLabel parses a port range configuration string and returns
+// one PortConfig per port in the range. The configuration string format is:
+//
+//	"<proxy range>/<protocol>:<target range>/<protocol>"
+//
+// Both proxy and target ranges must have the same number of ports, or one of
+// them can be a single port (which is reused for every port in the other range).
+// The options string (comma-separated after the config) is applied to all expanded ports.
+//
+// Examples:
+//   - "56000-56100/udp:56000-56100/udp" → 101 individual UDP PortConfigs
+//   - "56000-56100/udp:8080/udp"         → 101 UDP PortConfigs, all targeting port 8080
+//
+// Returns a map key prefix → PortConfig for each expanded port.
+func ExpandPortRangeLabel(s string) (map[string]PortConfig, error) {
+	separator := detectSeparator(s)
+	if separator == redirectSeparator {
+		return nil, fmt.Errorf("port ranges are not supported with redirect syntax")
+	}
+
+	parts := strings.Split(s, separator)
+	if len(parts) != 2 { //nolint:mnd
+		return nil, ErrInvalidProxyConfig
+	}
+
+	proxyParts := strings.SplitN(parts[0], protocolSeparator, 2)
+	proxyProtocol := "https"
+	if len(proxyParts) == 2 { //nolint:mnd
+		proxyProtocol = proxyParts[1]
+	}
+
+	targetParts := strings.SplitN(parts[1], protocolSeparator, 2)
+	targetProtocol := defaultTargetProtocol(proxyProtocol)
+	if len(targetParts) == 2 { //nolint:mnd
+		targetProtocol = targetParts[1]
+	}
+
+	var proxyPorts, targetPorts []int
+
+	if isPortRange(proxyParts[0]) {
+		start, end, err := parsePortRange(proxyParts[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy port range: %w", err)
+		}
+		for p := start; p <= end; p++ {
+			proxyPorts = append(proxyPorts, p)
+		}
+	} else {
+		port, err := strconv.Atoi(proxyParts[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy port: %w", err)
+		}
+		if err := validatePortRange(port); err != nil {
+			return nil, fmt.Errorf("invalid proxy port: %w", err)
+		}
+		proxyPorts = []int{port}
+	}
+
+	if isPortRange(targetParts[0]) {
+		start, end, err := parsePortRange(targetParts[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid target port range: %w", err)
+		}
+		for p := start; p <= end; p++ {
+			targetPorts = append(targetPorts, p)
+		}
+	} else {
+		port, err := strconv.Atoi(targetParts[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid target port: %w", err)
+		}
+		if err := validatePortRange(port); err != nil {
+			return nil, fmt.Errorf("invalid target port: %w", err)
+		}
+		targetPorts = []int{port}
+	}
+
+	if len(proxyPorts) > 1 && len(targetPorts) > 1 && len(proxyPorts) != len(targetPorts) {
+		return nil, fmt.Errorf("proxy range (%d ports) and target range (%d ports) must have the same length",
+			len(proxyPorts), len(targetPorts))
+	}
+
+	count := len(proxyPorts)
+	if len(targetPorts) > count {
+		count = len(targetPorts)
+	}
+
+	result := make(map[string]PortConfig, count)
+
+	for i := range count {
+		proxyPort := proxyPorts[0]
+		if len(proxyPorts) > 1 {
+			proxyPort = proxyPorts[i]
+		}
+
+		targetPort := targetPorts[0]
+		if len(targetPorts) > 1 {
+			targetPort = targetPorts[i]
+		}
+
+		name := fmt.Sprintf("%d/%s:%d/%s", proxyPort, proxyProtocol, targetPort, targetProtocol)
+
+		targetURL, err := url.Parse(targetProtocol + "://0.0.0.0:" + strconv.Itoa(targetPort))
+		if err != nil {
+			return nil, fmt.Errorf("error parsing target URL: %w", err)
+		}
+
+		cfg := PortConfig{
+			name:          name,
+			ProxyProtocol: proxyProtocol,
+			ProxyPort:     proxyPort,
+			IsRedirect:    false,
+			TLSValidate:   true,
+			targets:       []*url.URL{targetURL},
+		}
+
+		key := fmt.Sprintf("range_%d", i)
+		result[key] = cfg
+	}
+
+	return result, nil
+}
+
+// ExpandPortRangeShortLabel parses a short label that may contain a port range
+// (e.g., "56000-56100/udp") and returns one PortConfig per port.
+func ExpandPortRangeShortLabel(s string) (map[string]PortConfig, error) {
+	proxyParts := strings.SplitN(s, protocolSeparator, 2)
+	proxyProtocol := "https"
+	if len(proxyParts) == 2 { //nolint:mnd
+		proxyProtocol = proxyParts[1]
+	}
+
+	if !isPortRange(proxyParts[0]) {
+		cfg, err := NewPortShortLabel(s)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]PortConfig{"range_0": cfg}, nil
+	}
+
+	start, end, err := parsePortRange(proxyParts[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid port range: %w", err)
+	}
+
+	result := make(map[string]PortConfig, end-start+1)
+
+	for idx, p := 0, start; p <= end; idx, p = idx+1, p+1 {
+		name := fmt.Sprintf("%d/%s", p, proxyProtocol)
+		cfg := PortConfig{
+			name:          name,
+			ProxyProtocol: proxyProtocol,
+			ProxyPort:     p,
+			IsRedirect:    false,
+			TLSValidate:   true,
+		}
+		key := fmt.Sprintf("range_%d", idx)
+		result[key] = cfg
+	}
+
+	return result, nil
+}
+
+// IsPortRangeShortLabel checks whether a short label uses range syntax.
+func IsPortRangeShortLabel(s string) bool {
+	portPart := strings.SplitN(s, protocolSeparator, 2)[0]
+	return isPortRange(portPart)
 }

--- a/internal/model/port_test.go
+++ b/internal/model/port_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 )
@@ -291,4 +292,319 @@ func urlMustParse(s string) *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+func TestIsPortRange(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"56000-56100", true},
+		{"1-10", true},
+		{"443", false},
+		{"abc-def", false},
+		{"56000", false},
+		{"", false},
+		{"56000-", false},
+		{"-56100", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isPortRange(tt.input); got != tt.want {
+				t.Errorf("isPortRange(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePortRange(t *testing.T) {
+	t.Run("valid range", func(t *testing.T) {
+		start, end, err := parsePortRange("56000-56100")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start != 56000 || end != 56100 {
+			t.Errorf("got start=%d end=%d, want start=56000 end=56100", start, end)
+		}
+	})
+
+	t.Run("single port range", func(t *testing.T) {
+		start, end, err := parsePortRange("8080-8080")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start != 8080 || end != 8080 {
+			t.Errorf("got start=%d end=%d, want start=8080 end=8080", start, end)
+		}
+	})
+
+	t.Run("inverted range", func(t *testing.T) {
+		_, _, err := parsePortRange("100-50")
+		if err == nil {
+			t.Error("expected error for inverted range")
+		}
+	})
+
+	t.Run("out of range", func(t *testing.T) {
+		_, _, err := parsePortRange("1-70000")
+		if err == nil {
+			t.Error("expected error for port > 65535")
+		}
+	})
+
+	t.Run("zero port", func(t *testing.T) {
+		_, _, err := parsePortRange("0-10")
+		if err == nil {
+			t.Error("expected error for port 0")
+		}
+	})
+
+	t.Run("invalid format", func(t *testing.T) {
+		_, _, err := parsePortRange("abc")
+		if err == nil {
+			t.Error("expected error for non-numeric")
+		}
+	})
+}
+
+func TestIsPortRangeLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"range both sides", "56000-56100/udp:56000-56100/udp", true},
+		{"range proxy only", "56000-56100/udp:8080/udp", true},
+		{"range target only", "443/https:8080-8090/http", true},
+		{"no range", "443/https:80/http", false},
+		{"single port", "443:80", false},
+		{"redirect", "443/https->https://example.com", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPortRangeLabel(tt.input); got != tt.want {
+				t.Errorf("IsPortRangeLabel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandPortRangeLabel_BothRanges(t *testing.T) {
+	result, err := ExpandPortRangeLabel("56000-56002/udp:56000-56002/udp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 expanded ports, got %d", len(result))
+	}
+
+	expected := []struct {
+		proxyPort  int
+		targetHost string
+	}{
+		{56000, "0.0.0.0:56000"},
+		{56001, "0.0.0.0:56001"},
+		{56002, "0.0.0.0:56002"},
+	}
+
+	for i, exp := range expected {
+		key := "range_0"
+		if i == 1 {
+			key = "range_1"
+		} else if i == 2 {
+			key = "range_2"
+		}
+		cfg, ok := result[key]
+		if !ok {
+			t.Fatalf("missing key %q", key)
+		}
+		if cfg.ProxyPort != exp.proxyPort {
+			t.Errorf("port %d: ProxyPort = %d, want %d", i, cfg.ProxyPort, exp.proxyPort)
+		}
+		if cfg.ProxyProtocol != "udp" {
+			t.Errorf("port %d: ProxyProtocol = %q, want \"udp\"", i, cfg.ProxyProtocol)
+		}
+		target := cfg.GetFirstTarget()
+		if target.Scheme != "udp" {
+			t.Errorf("port %d: target scheme = %q, want \"udp\"", i, target.Scheme)
+		}
+		if target.Host != exp.targetHost {
+			t.Errorf("port %d: target host = %q, want %q", i, target.Host, exp.targetHost)
+		}
+	}
+}
+
+func TestExpandPortRangeLabel_ProxyRangeSingleTarget(t *testing.T) {
+	result, err := ExpandPortRangeLabel("56000-56002/udp:8080/udp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 expanded ports, got %d", len(result))
+	}
+
+	for i, key := range []string{"range_0", "range_1", "range_2"} {
+		cfg := result[key]
+		target := cfg.GetFirstTarget()
+		if target.Host != "0.0.0.0:8080" {
+			t.Errorf("port %d: target host = %q, want \"0.0.0.0:8080\"", i, target.Host)
+		}
+	}
+}
+
+func TestExpandPortRangeLabel_SingleProxyRangeTarget(t *testing.T) {
+	result, err := ExpandPortRangeLabel("8080/udp:56000-56002/udp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 expanded ports, got %d", len(result))
+	}
+
+	for i, key := range []string{"range_0", "range_1", "range_2"} {
+		cfg := result[key]
+		if cfg.ProxyPort != 8080 {
+			t.Errorf("port %d: ProxyPort = %d, want 8080", i, cfg.ProxyPort)
+		}
+	}
+}
+
+func TestExpandPortRangeLabel_MismatchedRanges(t *testing.T) {
+	_, err := ExpandPortRangeLabel("56000-56002/udp:60000-60005/udp")
+	if err == nil {
+		t.Error("expected error for mismatched range lengths")
+	}
+}
+
+func TestExpandPortRangeLabel_RedirectRejected(t *testing.T) {
+	_, err := ExpandPortRangeLabel("56000-56002/udp->https://example.com")
+	if err == nil {
+		t.Error("expected error for redirect with range")
+	}
+}
+
+func TestExpandPortRangeLabel_InvalidProxyRange(t *testing.T) {
+	_, err := ExpandPortRangeLabel("abc-def/udp:8080/udp")
+	if err == nil {
+		t.Error("expected error for invalid proxy range")
+	}
+}
+
+func TestExpandPortRangeLabel_InvalidTargetRange(t *testing.T) {
+	_, err := ExpandPortRangeLabel("8080/udp:abc-def/udp")
+	if err == nil {
+		t.Error("expected error for invalid target range")
+	}
+}
+
+func TestExpandPortRangeLabel_TCPRange(t *testing.T) {
+	result, err := ExpandPortRangeLabel("5000-5002/tcp:4000-4002/tcp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 expanded ports, got %d", len(result))
+	}
+
+	cfg := result["range_0"]
+	if cfg.ProxyProtocol != "tcp" {
+		t.Errorf("ProxyProtocol = %q, want \"tcp\"", cfg.ProxyProtocol)
+	}
+	target := cfg.GetFirstTarget()
+	if target.Scheme != "tcp" {
+		t.Errorf("target scheme = %q, want \"tcp\"", target.Scheme)
+	}
+	if cfg.ProxyPort != 5000 {
+		t.Errorf("ProxyPort = %d, want 5000", cfg.ProxyPort)
+	}
+	if target.Host != "0.0.0.0:4000" {
+		t.Errorf("target host = %q, want \"0.0.0.0:4000\"", target.Host)
+	}
+}
+
+func TestExpandPortRangeLabel_DefaultProtocol(t *testing.T) {
+	result, err := ExpandPortRangeLabel("56000-56001:56000-56001")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg := result["range_0"]
+	if cfg.ProxyProtocol != "https" {
+		t.Errorf("ProxyProtocol = %q, want \"https\" (default)", cfg.ProxyProtocol)
+	}
+	target := cfg.GetFirstTarget()
+	if target.Scheme != "http" {
+		t.Errorf("target scheme = %q, want \"http\" (default)", target.Scheme)
+	}
+}
+
+func TestIsPortRangeShortLabel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"56000-56100/udp", true},
+		{"56000-56100", true},
+		{"443/https", false},
+		{"443", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsPortRangeShortLabel(tt.input); got != tt.want {
+				t.Errorf("IsPortRangeShortLabel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandPortRangeShortLabel(t *testing.T) {
+	result, err := ExpandPortRangeShortLabel("56000-56002/udp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 expanded ports, got %d", len(result))
+	}
+
+	expected := []int{56000, 56001, 56002}
+	for i, port := range expected {
+		key := fmt.Sprintf("range_%d", i)
+		cfg, ok := result[key]
+		if !ok {
+			t.Fatalf("missing key %q", key)
+		}
+		if cfg.ProxyPort != port {
+			t.Errorf("entry %d: ProxyPort = %d, want %d", i, cfg.ProxyPort, port)
+		}
+		if cfg.ProxyProtocol != "udp" {
+			t.Errorf("entry %d: ProxyProtocol = %q, want \"udp\"", i, cfg.ProxyProtocol)
+		}
+	}
+}
+
+func TestExpandPortRangeShortLabel_NotRange(t *testing.T) {
+	result, err := ExpandPortRangeShortLabel("443/https")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(result))
+	}
+
+	cfg := result["range_0"]
+	if cfg.ProxyPort != 443 {
+		t.Errorf("ProxyPort = %d, want 443", cfg.ProxyPort)
+	}
+	if cfg.ProxyProtocol != "https" {
+		t.Errorf("ProxyProtocol = %q, want \"https\"", cfg.ProxyProtocol)
+	}
 }

--- a/internal/proxyproviders/tailscale/proxy.go
+++ b/internal/proxyproviders/tailscale/proxy.go
@@ -6,8 +6,10 @@ package tailscale
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"strconv"
 	"strings"
@@ -165,8 +167,43 @@ func (p *Proxy) GetPacketConn(port string) (net.PacketConn, error) {
 		return nil, ErrProxyPortNotFound
 	}
 
-	addr := ":" + strconv.Itoa(portCfg.ProxyPort)
+	ip4, err := p.waitForIP(p.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot bind UDP port %d: %w", portCfg.ProxyPort, err)
+	}
+
+	addr := ip4.String() + ":" + strconv.Itoa(portCfg.ProxyPort)
 	return p.tsServer.ListenPacket("udp", addr)
+}
+
+func (p *Proxy) waitForIP(ctx context.Context) (netip.Addr, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	const (
+		interval = 500 * time.Millisecond
+		timeout  = 30 * time.Second
+	)
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		ip4, _ := p.tsServer.TailscaleIPs()
+		if ip4.IsValid() {
+			return ip4, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return netip.Addr{}, errors.New("timed out waiting for tailscale IP")
+		case <-ticker.C:
+		}
+	}
 }
 
 func (p *Proxy) WatchEvents() chan model.ProxyEvent {

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -221,6 +221,45 @@ func (c *container) getPorts() model.PortConfigList {
 
 		parts := strings.Split(v, ",")
 
+		configStr := parts[0]
+
+		if model.IsPortRangeLabel(configStr) {
+			expanded, err := model.ExpandPortRangeLabel(configStr)
+			if err != nil {
+				c.log.Error().Err(err).Str("port", k).Msg("error expanding port range")
+				continue
+			}
+
+			for rangeKey, port := range expanded {
+				for _, opt := range parts[1:] {
+					opt = strings.TrimSpace(opt)
+					switch opt {
+					case PortOptionNoTLSValidate:
+						port.TLSValidate = false
+					case PortOptionTailscaleFunnel:
+						port.Tailscale.Funnel = true
+					case PortOptionNoAutoDetect:
+						port.NoAutoDetect = true
+					default:
+						c.log.Warn().Str("option", opt).Str("port", k).
+							Msg("unrecognized port option (valid: no_tlsvalidate, tailscale_funnel, no_autodetect)")
+					}
+				}
+
+				if !port.IsRedirect {
+					port, err = c.generateTargetFromFirstTarget(port)
+					if err != nil {
+						c.log.Error().Err(err).Str("port", k).Msg("error generating target for range port")
+						continue
+					}
+				}
+
+				expandedKey := k + "." + rangeKey
+				ports[expandedKey] = port
+			}
+			continue
+		}
+
 		port, err := model.NewPortLongLabel(parts[0])
 		if err != nil {
 			c.log.Error().Err(err).Str("port", k).Msg("error creating port config")

--- a/internal/targetproviders/list/list.go
+++ b/internal/targetproviders/list/list.go
@@ -290,6 +290,39 @@ func (c *Client) addTarget(cfg proxyConfig, name string) {
 func (c *Client) getPorts(l map[string]port) model.PortConfigList {
 	ports := make(model.PortConfigList)
 	for k, v := range l {
+		if model.IsPortRangeShortLabel(k) {
+			expanded, err := model.ExpandPortRangeShortLabel(k)
+			if err != nil {
+				c.log.Error().Err(err).Str("port", k).Msg("error expanding port range")
+				continue
+			}
+
+			for rangeKey, portCfg := range expanded {
+				portCfg.IsRedirect = v.IsRedirect
+
+				for _, target := range v.Targets {
+					targetURL, err := url.Parse(target)
+					if err != nil || targetURL.Scheme == "" || targetURL.Host == "" {
+						c.log.Error().Err(err).Str("port", k).Str("targetUrl", target).Msg("Invalid target URL")
+						continue
+					}
+					portCfg.AddTarget(targetURL)
+				}
+
+				if len(portCfg.GetTargets()) == 0 {
+					c.log.Error().Str("port", k).Msg("no targets found for range port")
+					continue
+				}
+
+				portCfg.TLSValidate = v.TLSValidate
+				portCfg.Tailscale = v.Tailscale
+
+				expandedKey := k + "." + rangeKey
+				ports[expandedKey] = portCfg
+			}
+			continue
+		}
+
 		port, err := model.NewPortShortLabel(k)
 		if err != nil {
 			c.log.Error().Err(err).Str("port", k).Msg("error creating port config")
@@ -301,7 +334,6 @@ func (c *Client) getPorts(l map[string]port) model.PortConfigList {
 			targetURL, err := url.Parse(target)
 			if err != nil || targetURL.Scheme == "" || targetURL.Host == "" {
 				c.log.Error().Err(err).Str("port", k).Str("targetUrl", target).Msg("Invalid target URL")
-				// don't add this port and continue with other targets
 				continue
 			}
 


### PR DESCRIPTION
## Summary

Closes #420

Adds range syntax to port configuration so users can forward a range of UDP/TCP ports through Tailscale (e.g. for WebRTC/neko).

**Syntax**: `56000-56002/udp:56000-56002/udp` — expands at parse time into individual `PortConfig` entries.

## Changes

### Core (`internal/model/port.go`)
- `isPortRange`, `parsePortRange` — detect/validate `start-end` syntax (max 1000 ports)
- `ExpandPortRangeLabel` — expands long-label ranges for Docker provider
- `ExpandPortRangeShortLabel` — expands short-label ranges for list provider
- `IsPortRangeLabel`, `IsPortRangeShortLabel` — range detection
- `defaultTargetProtocol` helper — extracted from duplicated protocol inference logic

### Docker provider (`internal/targetproviders/docker/container.go`)
- Range labels detected and expanded; options applied per expanded port
- Added `default:` warning for unrecognized options in range path (was silently ignored)

### List provider (`internal/targetproviders/list/list.go`)
- Range short labels detected and expanded with target assignment

### Tailscale UDP fix (`internal/proxyproviders/tailscale/proxy.go`)
- `GetPacketConn` now waits for actual Tailscale IP via `waitForIP` polling (`tsnet.ListenPacket` rejects `0.0.0.0`)
- `waitForIP` guards against nil `ctx`

### Bug fixes
- `ExpandPortRangeShortLabel` now sets `TLSValidate: true` (was zero-value `false`)
- Consistent `range_0` key for non-range fallback in short label expansion

### Tests
- 13 new test functions covering all range parsing/expansion paths

### Dev config
- Docker compose and list provider examples with port ranges
- Makefile `make run` updated to use dev config