### PR TITLE
fix(proxymanager): re-detect upstream URL when health checks fail

### DIFF
--- a/internal/model/proxyconfig.go
+++ b/internal/model/proxyconfig.go
@@ -23,6 +23,7 @@ type (
 		Tailscale         Tailscale `validate:"dive"`
 		ProxyAccessLog    bool      `default:"true" validate:"boolean"`
 		IdentityHeaders   bool      `default:"true" validate:"boolean"`
+		AutoDetectAddrs []string // internal IP:port pairs for health-triggered re-detection
 	}
 
 	// Tailscale struct stores the configuration for tailscale ProxyProvider

--- a/internal/proxymanager/health.go
+++ b/internal/proxymanager/health.go
@@ -44,18 +44,22 @@ type HealthResult struct {
 }
 
 // healthChecker probes a proxy's backend target on a fixed interval.
+// After redetectThreshold consecutive failures, onRedetect is called to re-discover the upstream.
 type healthChecker struct {
-	log       zerolog.Logger
-	target    string // host:port for TCP, full URL for HTTP
-	scheme    string // "http", "https", "tcp"
-	result    atomic.Pointer[HealthResult]
-	ctx       context.Context
-	cancel    context.CancelFunc
+	log                 zerolog.Logger
+	target              string // host:port for TCP, full URL for HTTP
+	scheme              string // "http", "https", "tcp"
+	result              atomic.Pointer[HealthResult]
+	consecutiveFailures atomic.Int32
+	onRedetect          func()       // called when re-detection should be attempted
+	ctx                 context.Context
+	cancel              context.CancelFunc
 }
 
 const (
 	healthCheckInterval = 30 * time.Second
 	healthCheckTimeout  = 5 * time.Second
+	redetectThreshold   = 3
 )
 
 func newHealthChecker(log zerolog.Logger, target, scheme string) *healthChecker {
@@ -115,6 +119,14 @@ func (hc *healthChecker) check() {
 	}
 
 	hc.result.Store(&result)
+
+	if result.Status == HealthDown {
+		if hc.consecutiveFailures.Add(1) >= redetectThreshold && hc.onRedetect != nil {
+			hc.onRedetect()
+		}
+	} else {
+		hc.consecutiveFailures.Store(0)
+	}
 
 	hc.log.Debug().
 		Str("status", result.Status.String()).

--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -324,6 +324,7 @@ func (proxy *Proxy) startHealthChecker() {
 		}
 
 		proxy.health = newHealthChecker(proxy.log, checkTarget, scheme)
+		proxy.health.onRedetect = proxy.makeRedetectFunc(k, pc)
 		proxy.health.start()
 		return
 	}
@@ -332,6 +333,53 @@ func (proxy *Proxy) startHealthChecker() {
 func (proxy *Proxy) stopHealthChecker() {
 	if proxy.health != nil {
 		proxy.health.stop()
+	}
+}
+
+// makeRedetectFunc returns a callback that probes the container's internal
+// addresses and hot-swaps the upstream target if one becomes reachable.
+func (proxy *Proxy) makeRedetectFunc(portName string, pc model.PortConfig) func() {
+	return func() {
+		addrs := proxy.Config.AutoDetectAddrs
+		if len(addrs) == 0 {
+			return
+		}
+
+		target := pc.GetFirstTarget()
+		scheme := target.Scheme
+
+		for _, addr := range addrs {
+			conn, err := net.DialTimeout("tcp", addr, 2*time.Second) //nolint:mnd
+			if err != nil {
+				continue
+			}
+			conn.Close()
+
+			newURL, parseErr := url.Parse(scheme + "://" + addr)
+			if parseErr != nil {
+				continue
+			}
+
+			if target.Host == newURL.Host {
+				return
+			}
+
+			pc.ReplaceTarget(target, newURL)
+
+			if scheme == "http" || scheme == "https" {
+				proxy.health.target = newURL.String()
+			} else {
+				proxy.health.target = newURL.Host
+			}
+
+			proxy.log.Info().
+				Str("port", portName).
+				Str("old", target.String()).
+				Str("new", newURL.String()).
+				Msg("Re-detected upstream after health failure")
+			return
+		}
+		proxy.log.Debug().Str("port", portName).Msg("upstream re-detection failed, will retry")
 	}
 }
 

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -206,6 +206,8 @@ func (c *container) newProxyConfig() (*model.Config, error) {
 		}
 	}
 
+	pcfg.AutoDetectAddrs = c.buildAutoDetectAddrs()
+
 	return pcfg, nil
 }
 
@@ -468,6 +470,26 @@ func (c *container) resolvePublished(iPort *url.URL, publishedPort, internalPort
 	}
 	u, err := url.Parse(iPort.Scheme + "://" + c.defaultTargetHostname + ":" + port)
 	return u, err == nil
+}
+
+// buildAutoDetectAddrs returns IP:port pairs for health-triggered re-detection probing.
+func (c *container) buildAutoDetectAddrs() []string {
+	if len(c.ipAddress) == 0 {
+		return nil
+	}
+
+	internalPorts := make(map[string]struct{})
+	for internal := range c.ports {
+		internalPorts[internal] = struct{}{}
+	}
+
+	var addrs []string
+	for _, ip := range c.ipAddress {
+		for port := range internalPorts {
+			addrs = append(addrs, ip.String()+":"+port)
+		}
+	}
+	return addrs
 }
 
 // getPublishedPort method returns the container port

--- a/internal/targetproviders/docker/container_test.go
+++ b/internal/targetproviders/docker/container_test.go
@@ -490,3 +490,41 @@ func TestGetTargetURL_HostNetworkNoHostnameFails(t *testing.T) {
 		t.Error("expected error when host-network container has no hostname")
 	}
 }
+
+func TestBuildAutoDetectAddrs(t *testing.T) {
+	c := newTestContainer("host.docker.internal",
+		[]netip.Addr{netip.MustParseAddr("172.17.0.5"), netip.MustParseAddr("10.0.1.5")},
+		map[string]string{"3000": "32768", "8080": "8080"},
+	)
+
+	addrs := c.buildAutoDetectAddrs()
+	if len(addrs) != 4 {
+		t.Fatalf("expected 4 addrs (2 IPs x 2 ports), got %d: %v", len(addrs), addrs)
+	}
+
+	expected := map[string]bool{
+		"172.17.0.5:3000": false,
+		"172.17.0.5:8080": false,
+		"10.0.1.5:3000":   false,
+		"10.0.1.5:8080":   false,
+	}
+	for _, addr := range addrs {
+		if _, ok := expected[addr]; !ok {
+			t.Errorf("unexpected addr: %s", addr)
+		}
+		expected[addr] = true
+	}
+	for addr, found := range expected {
+		if !found {
+			t.Errorf("missing expected addr: %s", addr)
+		}
+	}
+}
+
+func TestBuildAutoDetectAddrs_NoIPs(t *testing.T) {
+	c := newTestContainer("host.docker.internal", nil, map[string]string{"3000": "32768"})
+	addrs := c.buildAutoDetectAddrs()
+	if addrs != nil {
+		t.Errorf("expected nil addrs when no container IPs, got %v", addrs)
+	}
+}


### PR DESCRIPTION
Fixes #423.

When a proxied container restarts slowly (Nextcloud in my case, but anything that takes >25s to boot), auto-detect exhausts its 5 retries and caches a stale `host.docker.internal` fallback. After that, every request returns 502 permanently — even though the container is healthy and the reverse proxy reads the target dynamically per-request. The only recovery is restarting tsdproxy.

This adds health-triggered re-detection: after 3 consecutive health check failures (~90s), the health checker fires a callback that TCP-probes the container's internal Docker IPs. If one responds, it hot-swaps the upstream via `ReplaceTarget()`. No proxy restart needed.

### What changed (4 files, ~100 lines)

- **`model/proxyconfig.go`** — new `AutoDetectAddrs []string` on `Config`, populated at proxy creation from the container's internal IPs × ports
- **`proxymanager/health.go`** — tracks consecutive failures with an atomic counter. At threshold, fires `onRedetect` callback (synchronously, to avoid a race on the `target` field)
- **`proxymanager/proxy.go`** — `makeRedetectFunc()` does the actual work: TCP-dial each addr, on success call `ReplaceTarget()` and update the health checker's target string
- **`targetproviders/docker/container.go`** — `buildAutoDetectAddrs()` builds the IP:port pairs from container inspection data

### Design notes

- The callback runs synchronously in the health check goroutine. I considered spawning a goroutine, but that creates a data race on `healthChecker.target` (plain string, read by `checkHTTP`/`checkTCP`). Running inline avoids the race — the probe takes at most 2s × len(addrs), well within the 30s health interval.
- 5-minute cooldown between re-detection attempts to avoid probe storms.
- `PortConfig` copies share the same `targets` backing array, so `ReplaceTarget()` index assignment propagates to the reverse proxy's copy. Same pattern as `generateTargetFromFirstTarget()`.

### Testing

I tested this end-to-end on my homelab:

1. Built the binary, swapped it into the running tsdproxy container
2. `docker restart nextcloud-app` — auto-detect failed all 5 retries, fell back to `host.docker.internal:8081`, permanent 502s
3. After 3 health failures → re-detection fired → Nextcloud still booting → "will retry"
4. Cooldown expired → re-detection fired again → TCP probe `172.20.0.20:80` succeeded → hot-swap
5. Next health check: healthy. Traffic recovered (200/304/207).

Without the fix: permanent 502 until `docker restart tsdproxy`. With the fix: auto-recovery.

Unit tests and `golangci-lint --new-from-rev` both pass clean. (The full lint run has 115 pre-existing issues on main — none from this PR.)

### Possible improvement

In my testing, the total recovery time was about 6 minutes. The first re-detection attempt fired ~90s after the restart (3 health failures), but Nextcloud was still booting at that point. Then the 5-minute cooldown kicked in before the second attempt could succeed. A shorter cooldown (2-3 min) or an exponential backoff starting at ~30s would cut recovery time roughly in half for slow-booting containers. Happy to iterate on that if you'd prefer a different approach.