### PR TITLE
fix(proxymanager): re-detect upstream URL when health checks fail

### DIFF
--- a/internal/model/proxyconfig.go
+++ b/internal/model/proxyconfig.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/creasty/defaults"
 )
@@ -23,6 +24,7 @@ type (
 		Tailscale         Tailscale `validate:"dive"`
 		ProxyAccessLog    bool      `default:"true" validate:"boolean"`
 		IdentityHeaders   bool      `default:"true" validate:"boolean"`
+		RedetectTarget func() (*url.URL, bool) `json:"-" yaml:"-" validate:"-"`
 	}
 
 	// Tailscale struct stores the configuration for tailscale ProxyProvider

--- a/internal/proxymanager/health.go
+++ b/internal/proxymanager/health.go
@@ -44,18 +44,22 @@ type HealthResult struct {
 }
 
 // healthChecker probes a proxy's backend target on a fixed interval.
+// After redetectThreshold consecutive failures, onRedetect is called to re-discover the upstream.
 type healthChecker struct {
-	log       zerolog.Logger
-	target    string // host:port for TCP, full URL for HTTP
-	scheme    string // "http", "https", "tcp"
-	result    atomic.Pointer[HealthResult]
-	ctx       context.Context
-	cancel    context.CancelFunc
+	log                 zerolog.Logger
+	target              string // host:port for TCP, full URL for HTTP
+	scheme              string // "http", "https", "tcp"
+	result              atomic.Pointer[HealthResult]
+	consecutiveFailures atomic.Int32
+	onRedetect          func() // called when re-detection should be attempted
+	ctx                 context.Context
+	cancel              context.CancelFunc
 }
 
 const (
 	healthCheckInterval = 30 * time.Second
 	healthCheckTimeout  = 5 * time.Second
+	redetectThreshold   = 3
 )
 
 func newHealthChecker(log zerolog.Logger, target, scheme string) *healthChecker {
@@ -115,6 +119,14 @@ func (hc *healthChecker) check() {
 	}
 
 	hc.result.Store(&result)
+
+	if result.Status == HealthDown {
+		if hc.consecutiveFailures.Add(1) >= redetectThreshold && hc.onRedetect != nil {
+			hc.onRedetect()
+		}
+	} else {
+		hc.consecutiveFailures.Store(0)
+	}
 
 	hc.log.Debug().
 		Str("status", result.Status.String()).

--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -324,6 +324,7 @@ func (proxy *Proxy) startHealthChecker() {
 		}
 
 		proxy.health = newHealthChecker(proxy.log, checkTarget, scheme)
+		proxy.health.onRedetect = proxy.makeRedetectFunc(k, pc)
 		proxy.health.start()
 		return
 	}
@@ -332,6 +333,49 @@ func (proxy *Proxy) startHealthChecker() {
 func (proxy *Proxy) stopHealthChecker() {
 	if proxy.health != nil {
 		proxy.health.stop()
+	}
+}
+
+// makeRedetectFunc returns a callback that asks the target provider to
+// re-discover a reachable upstream and hot-swaps the target if it changed.
+func (proxy *Proxy) makeRedetectFunc(portName string, pc model.PortConfig) func() {
+	redetect := proxy.Config.RedetectTarget
+	if redetect == nil {
+		return nil
+	}
+
+	return func() {
+		found, ok := redetect()
+		if !ok {
+			proxy.log.Debug().Str("port", portName).Msg("upstream re-detection failed, will retry")
+			return
+		}
+
+		current := pc.GetFirstTarget()
+		scheme := current.Scheme
+
+		newURL := &url.URL{
+			Scheme: scheme,
+			Host:   found.Host,
+		}
+
+		if current.Host == newURL.Host {
+			return
+		}
+
+		pc.ReplaceTarget(current, newURL)
+
+		if scheme == "http" || scheme == "https" {
+			proxy.health.target = newURL.String()
+		} else {
+			proxy.health.target = newURL.Host
+		}
+
+		proxy.log.Info().
+			Str("port", portName).
+			Str("old", current.String()).
+			Str("new", newURL.String()).
+			Msg("Re-detected upstream after health failure")
 	}
 }
 

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -5,6 +5,7 @@ package docker
 
 import (
 	"fmt"
+	"net"
 	"net/netip"
 	"net/url"
 	"os"
@@ -205,6 +206,8 @@ func (c *container) newProxyConfig() (*model.Config, error) {
 			pcfg.Ports["legacy"] = legacyPort
 		}
 	}
+
+	pcfg.RedetectTarget = c.buildRedetectFunc()
 
 	return pcfg, nil
 }
@@ -468,6 +471,37 @@ func (c *container) resolvePublished(iPort *url.URL, publishedPort, internalPort
 	}
 	u, err := url.Parse(iPort.Scheme + "://" + c.defaultTargetHostname + ":" + port)
 	return u, err == nil
+}
+
+// buildRedetectFunc returns a closure that probes the container's internal
+// network addresses and returns the first reachable target URL.
+// Returns nil when the container has no internal IPs (e.g. host-network mode).
+func (c *container) buildRedetectFunc() func() (*url.URL, bool) {
+	if len(c.ipAddress) == 0 {
+		return nil
+	}
+
+	var addrs []string
+	for _, ip := range c.ipAddress {
+		for internal := range c.ports {
+			addrs = append(addrs, net.JoinHostPort(ip.String(), internal))
+		}
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+
+	return func() (*url.URL, bool) {
+		for _, addr := range addrs {
+			conn, err := net.DialTimeout("tcp", addr, dialTimeout)
+			if err != nil {
+				continue
+			}
+			conn.Close()
+			return &url.URL{Host: addr}, true
+		}
+		return nil, false
+	}
 }
 
 // getPublishedPort method returns the container port

--- a/internal/targetproviders/docker/container_test.go
+++ b/internal/targetproviders/docker/container_test.go
@@ -490,3 +490,29 @@ func TestGetTargetURL_HostNetworkNoHostnameFails(t *testing.T) {
 		t.Error("expected error when host-network container has no hostname")
 	}
 }
+
+func TestBuildRedetectFunc(t *testing.T) {
+	c := newTestContainer("host.docker.internal",
+		[]netip.Addr{netip.MustParseAddr("172.17.0.5"), netip.MustParseAddr("10.0.1.5")},
+		map[string]string{"3000": "32768", "8080": "8080"},
+	)
+
+	fn := c.buildRedetectFunc()
+	if fn == nil {
+		t.Fatal("expected non-nil redetect func for container with IPs")
+	}
+
+	// The closure won't find anything listening, so it should return false.
+	_, ok := fn()
+	if ok {
+		t.Error("expected redetect to fail when nothing is listening")
+	}
+}
+
+func TestBuildRedetectFunc_NoIPs(t *testing.T) {
+	c := newTestContainer("host.docker.internal", nil, map[string]string{"3000": "32768"})
+	fn := c.buildRedetectFunc()
+	if fn != nil {
+		t.Error("expected nil redetect func when no container IPs")
+	}
+}


### PR DESCRIPTION
Fixes #423. Supersedes #424.

## Problem

When a proxied container restarts and takes longer than the auto-detect window (~25s) to boot, detection fails and a stale fallback URL gets cached permanently. Every request returns 502 until tsdproxy is manually restarted.

## Solution

After 3 consecutive health check failures (~90s), the health checker fires a re-detection callback. The callback TCP-probes the container's internal Docker IPs and, if one responds, hot-swaps the upstream target via `ReplaceTarget()`. No proxy restart needed.

### Why this changed from #424

The original PR stored raw IP:port pairs (`AutoDetectAddrs []string`) on `model.Config` and did TCP probing directly in the proxy manager. After reviewing the recent resolver refactoring (commits 092306f, e63e2d0), I reworked the approach:

- **Closure instead of raw addresses**: The Docker target provider now builds a `RedetectTarget func() (*url.URL, bool)` closure that captures container IPs and ports. The proxy manager calls it and gets a URL back without knowing anything about Docker internals.
- **No cooldown timer**: The 30s health check interval is sufficient rate limiting. A 5-minute cooldown would delay recovery for no real benefit since the probes are cheap local TCP dials.
- **Provider-agnostic**: Providers that don't support re-detection (e.g. list provider) leave `RedetectTarget` nil and the callback is never wired up.

## What changed (5 files, ~120 lines)

- **`model/proxyconfig.go`**: new `RedetectTarget func() (*url.URL, bool)` field on `Config` (tagged `json:"-" yaml:"-"` since it's runtime-only)
- **`proxymanager/health.go`**: tracks consecutive failures via atomic counter, fires `onRedetect` callback at threshold
- **`proxymanager/proxy.go`**: `makeRedetectFunc()` calls the closure, applies the current scheme, hot-swaps if the host changed
- **`targetproviders/docker/container.go`**: `buildRedetectFunc()` builds the closure from container IPs x internal ports, uses existing `dialTimeout` constant
- **`targetproviders/docker/container_test.go`**: tests for closure construction and nil-IP case

## Testing

Tested end-to-end on my homelab with Nextcloud (slow starter, consistently reproduces #423):

1. `docker restart nextcloud-app` -- auto-detect fails all 5 retries, falls back to stale URL, permanent 502s
2. After 3 health failures, re-detection fires, Nextcloud still booting, "will retry"
3. Next re-detection attempt: TCP probe to 172.20.0.x:80 succeeds, hot-swap
4. Next health check: healthy. Traffic recovers.

Without the fix: permanent 502 until `docker restart tsdproxy`. With the fix: auto-recovery.

Unit tests and `golangci-lint --new-from-rev` both pass clean.