### PR TITLE
fix: Docker compatibility for adminAllowLocalhost, hostname default, and OAuth errors

### DIFF
--- a/docs/content/docs/changelog.md
+++ b/docs/content/docs/changelog.md
@@ -39,6 +39,9 @@ weight: 500
 - Fix session cookie hardening — improved `Secure` and `HttpOnly` flag handling
 - Fix version `isDirty` data race — eliminate race condition in version reporting
 - Fix Tailscale OAuth scopes — narrowed to minimum required permissions
+- Fix `adminAllowLocalhost` not working with Docker port mapping — the localhost check now also trusts RFC 1918 private networks (Docker bridge IPs), not just loopback
+- Fix Docker deployments requiring manual `hostname: 0.0.0.0` — the hostname is now automatically overridden to `0.0.0.0` when running inside a container
+- Fix OAuth tag rejection error message — surfaces actionable guidance about OAuth client tag assignment when Tailscale returns a 400
 - Fix WatchEvents CPU spin loop — add reconnection backoff when Docker event stream disconnects
 - Fix proxy Start/Close race — add mutex for Start/Close exclusion, fix port double-close
 - Fix proxy lifecycle ordering — guard metrics writes and fix proxy lifecycle ordering

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -100,14 +100,16 @@ authenticate with Tailscale.
 > The auto-generated config sets `http.hostname: 0.0.0.0` so the dashboard is
 > reachable through Docker port mapping. If you regenerate the config or upgrade
 > from a previous version, note that **the default is `127.0.0.1`** (localhost only).
-> If the dashboard is unreachable, set `hostname: 0.0.0.0` explicitly.
+> When running inside Docker, the hostname is automatically overridden to `0.0.0.0`.
+> For non-Docker setups, set `hostname: 0.0.0.0` explicitly if needed.
 > See [Troubleshooting]({{< ref "/docs/troubleshooting#dashboard-unreachable-after-upgrading-to-v220" >}}).
 
 > [!IMPORTANT]
 > All dashboard endpoints require authentication. When accessing via Docker port
 > mapping (not through a Tailscale proxy), enable
-> `adminAllowLocalhost: true` in your config. See
-> [Admin Allowlist]({{< ref "/docs/security/admin-allowlist" >}}) for details.
+> `adminAllowLocalhost: true` in your config. In Docker, this trusts requests
+> from the Docker bridge network automatically.
+> See [Admin Allowlist]({{< ref "/docs/security/admin-allowlist" >}}) for details.
 
 > [!TIP]
 > For automated authentication without manual browser login, configure OAuth or

--- a/docs/content/docs/security/admin-allowlist.md
+++ b/docs/content/docs/security/admin-allowlist.md
@@ -47,8 +47,9 @@ admins:
   - "12345"  # alice@github
   - "67890"  # bob@example.com
 
-# Permit localhost requests to bypass the allowlist (for bootstrapping).
-# Only enable this temporarily — any process on the host can then call
+# Permit localhost and private-network requests to bypass the allowlist (for bootstrapping).
+# This includes loopback (127.0.0.0/8, ::1) and RFC 1918 private IPs (Docker bridge, etc.).
+# Only enable this temporarily — any process on the host or Docker network can then call
 # admin endpoints.
 adminAllowLocalhost: false
 ```
@@ -58,7 +59,7 @@ adminAllowLocalhost: false
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `admins` | `[]string` | (empty) | List of Tailscale `UserProfile.ID` values. All tailnet users can view the dashboard; only listed IDs can perform admin actions. |
-| `adminAllowLocalhost` | `bool` | `false` | When `true`, requests from `127.0.0.0/8` or `::1` bypass the allowlist. Intended for bootstrapping only. |
+| `adminAllowLocalhost` | `bool` | `false` | When `true`, requests from loopback (`127.0.0.0/8`, `::1`) and RFC 1918 private networks (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) bypass the allowlist. The private-network check enables `adminAllowLocalhost` to work with Docker port mapping, where requests arrive from the Docker bridge gateway rather than `127.0.0.1`. Intended for bootstrapping only. |
 | `apiKey` | `string` | (empty) | Static API key for non-Tailscale authentication. Grants full admin access. |
 | `apiKeyFile` | `string` | (empty) | Path to a file containing the API key. Takes precedence over `apiKey`. |
 
@@ -201,7 +202,9 @@ management endpoints. The fix includes:
   localhost by generating a random token at startup and validating with
   constant-time comparison
 - **Default bind address changed** — `http.hostname` defaults to `127.0.0.1`
-  instead of `0.0.0.0`, reducing the attack surface when TSDProxy starts
+  instead of `0.0.0.0`, reducing the attack surface when TSDProxy starts.
+  When running inside Docker, the hostname is automatically overridden to
+  `0.0.0.0` so port-mapped access works without manual configuration.
 
 If upgrading from a previous version, you may need to:
 
@@ -219,6 +222,11 @@ your Tailscale proxy URL (e.g., `https://dash-dev.<tailnet>.ts.net`).
 
 If you need local access for bootstrapping, temporarily set
 `adminAllowLocalhost: true`.
+
+> [!NOTE]
+> When running inside Docker, `adminAllowLocalhost: true` trusts requests
+> from the Docker bridge network (not just `127.0.0.1`), so it works
+> correctly with port mapping (`-p 8080:8080`).
 
 ### "access denied" (403)
 

--- a/docs/content/docs/serverconfig.md
+++ b/docs/content/docs/serverconfig.md
@@ -216,9 +216,12 @@ Configures the built-in HTTP server that serves the dashboard and health endpoin
 
 The bind address for the HTTP server. Defaults to `127.0.0.1` (localhost only).
 
+When running inside Docker, the hostname is automatically overridden to `0.0.0.0`
+so that port-mapped access (`-p 8080:8080`) works without manual configuration.
+
 > [!WARNING]
-> The default changed from `0.0.0.0` to `127.0.0.1` in the latest release for security.
-> If you need the dashboard accessible on all interfaces (e.g. via Docker port mapping),
+> The default changed from `0.0.0.0` to `127.0.0.1` in v2.2.0 for security.
+> If you need the dashboard accessible on all interfaces outside Docker,
 > set `hostname: 0.0.0.0` explicitly.
 
 ##### port
@@ -372,13 +375,18 @@ Use `/api/whoami` through a Tailscale connection to discover your ID.
 
 ##### adminAllowLocalhost
 
-When `true`, requests originating from `localhost` bypass the admin allowlist.
-Defaults to `false`. Intended only for bootstrapping — enable temporarily,
-then disable once your ID is in the list.
+When `true`, requests originating from loopback (`127.0.0.0/8`, `::1`) or
+RFC 1918 private networks (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`)
+bypass the admin allowlist. Defaults to `false`. Intended only for
+bootstrapping — enable temporarily, then disable once your ID is in the list.
+
+The private-network check enables `adminAllowLocalhost` to work with Docker
+port mapping, where requests arrive from the Docker bridge gateway
+(e.g. `172.17.0.1`) rather than `127.0.0.1`.
 
 > [!WARNING]
-> With `adminAllowLocalhost: true`, any process on the host can call admin
-> endpoints without authentication.
+> With `adminAllowLocalhost: true`, any process on the host or Docker
+> network can call admin endpoints without authentication.
 
 {{% /steps %}}
 

--- a/docs/content/docs/troubleshooting.md
+++ b/docs/content/docs/troubleshooting.md
@@ -50,7 +50,10 @@ security (see [GHSA-j8rq-87gr-gm9q](https://github.com/almeidapaulopt/tsdproxy/s
 If you expose the dashboard via Docker port mapping (`ports: "8080:8080"`), the
 server only listens on localhost **inside** the container — unreachable from the host.
 
-**Fix:** set `hostname` explicitly in your `tsdproxy.yaml`:
+**When running in Docker**, the hostname is automatically overridden to `0.0.0.0`,
+so no manual configuration is needed.
+
+**For non-Docker setups**, set `hostname` explicitly in your `tsdproxy.yaml`:
 
 ```yaml
 http:
@@ -69,6 +72,10 @@ Tailscale identity to authenticate with.
 ```yaml
 adminAllowLocalhost: true
 ```
+
+When `adminAllowLocalhost` is enabled, requests from loopback (`127.0.0.0/8`)
+and RFC 1918 private networks (including Docker bridge IPs like `172.17.0.1`)
+are trusted. This works correctly with Docker port mapping out of the box.
 
 > ⚠️ Anyone who can reach port 8080 on your host will have admin access.
 > If the port is exposed to a network, consider restricting it or using an

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,8 @@ func InitializeConfig() error {
 			log.Error().Err(err).Msg("error loading defaults")
 		}
 
+		applyDockerHostnameDefault()
+
 		Config.generateDefaultProviders()
 		if err := fileConfig.Save(); err != nil {
 			return err
@@ -168,6 +170,8 @@ func InitializeConfig() error {
 	if err := defaults.Set(Config); err != nil {
 		log.Error().Err(err).Msg("error loading defaults")
 	}
+
+	applyDockerHostnameDefault()
 
 	// load auth keys from files
 	for _, d := range Config.Tailscale.Providers {
@@ -202,6 +206,24 @@ func InitializeConfig() error {
 	}
 
 	return nil
+}
+
+// applyDockerHostnameDefault overrides the HTTP hostname from 127.0.0.1 to
+// 0.0.0.0 when running inside a Docker container. Outside Docker the default
+// remains 127.0.0.1 per GHSA-j8rq-87gr-gm9q to avoid exposing management
+// endpoints on the network. Inside Docker, 127.0.0.1 is unreachable via
+// port mapping, so 0.0.0.0 is required.
+func applyDockerHostnameDefault() {
+	if isRunningInDocker() && Config.HTTP.Hostname == "127.0.0.1" {
+		Config.HTTP.Hostname = "0.0.0.0"
+		log.Info().Msg("running in Docker: defaulting http.hostname to 0.0.0.0")
+	}
+}
+
+// isRunningInDocker returns true if the process is running inside a Docker container.
+func isRunningInDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
 }
 
 func (c *config) getAuthKeyFromFile(authKeyFile string) (string, error) {

--- a/internal/core/admin.go
+++ b/internal/core/admin.go
@@ -69,7 +69,7 @@ func AdminMiddleware() Middleware {
 					return
 				}
 
-				if IsLocalhost(r.RemoteAddr) && config.Config.AdminAllowLocalhost {
+				if IsTrustedSource(r.RemoteAddr) && config.Config.AdminAllowLocalhost {
 					next.ServeHTTP(w, r)
 					return
 				}
@@ -83,7 +83,7 @@ func AdminMiddleware() Middleware {
 				return
 			}
 
-			if IsLocalhost(r.RemoteAddr) && config.Config.AdminAllowLocalhost {
+			if IsTrustedSource(r.RemoteAddr) && config.Config.AdminAllowLocalhost {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -110,7 +110,7 @@ func ViewerMiddleware() Middleware {
 				return
 			}
 
-			if IsLocalhost(r.RemoteAddr) && config.Config.AdminAllowLocalhost {
+			if IsTrustedSource(r.RemoteAddr) && config.Config.AdminAllowLocalhost {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -131,7 +131,7 @@ func IsAdmin(r *http.Request) bool {
 	if id != "" {
 		return UserIDIsAdmin(id)
 	}
-	return IsLocalhost(r.RemoteAddr) && config.Config.AdminAllowLocalhost
+	return IsTrustedSource(r.RemoteAddr) && config.Config.AdminAllowLocalhost
 }
 
 func UserIDIsAdmin(id string) bool {
@@ -212,6 +212,32 @@ func IsLocalhost(remoteAddr string) bool {
 	}
 
 	return ip.IsLoopback()
+}
+
+// IsTrustedSource returns true when the request originates from a
+// trusted network: loopback (127.0.0.0/8, ::1) or RFC 1918 private
+// addresses (172.16.0.0/12, 10.0.0.0/8, 192.168.0.0/16).
+//
+// The private-network check extends the loopback-only IsLocalhost to
+// cover Docker port-mapped requests, which arrive inside the container
+// from the Docker bridge gateway (e.g. 172.17.0.1) rather than
+// 127.0.0.1.
+//
+// IMPORTANT: This must NOT be used where loopback-only trust is
+// required (e.g. validating proxy auth tokens or identity headers).
+// Use IsLocalhost for those cases.
+func IsTrustedSource(remoteAddr string) bool {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate()
 }
 
 // validProxyAuthToken checks whether the request carries a valid per-process

--- a/internal/core/admin_test.go
+++ b/internal/core/admin_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Paulo Almeida <almeidapaulopt@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package core
+
+import "testing"
+
+func TestIsLocalhost(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       bool
+	}{
+		{"IPv4 loopback", "127.0.0.1:12345", true},
+		{"IPv4 loopback other", "127.0.0.2:8080", true},
+		{"IPv6 loopback", "[::1]:8080", true},
+		{"Docker bridge", "172.17.0.1:8080", false},
+		{"Private 10.x", "10.0.0.1:8080", false},
+		{"Private 192.168.x", "192.168.1.1:8080", false},
+		{"Public IP", "8.8.8.8:8080", false},
+		{"no port loopback", "127.0.0.1", true},
+		{"no port docker bridge", "172.17.0.1", false},
+		{"hostname", "example.com:8080", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLocalhost(tt.remoteAddr); got != tt.want {
+				t.Errorf("IsLocalhost(%q) = %v, want %v", tt.remoteAddr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsTrustedSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       bool
+	}{
+		{"IPv4 loopback", "127.0.0.1:12345", true},
+		{"IPv4 loopback other", "127.0.0.2:8080", true},
+		{"IPv6 loopback", "[::1]:8080", true},
+		{"Docker bridge default", "172.17.0.1:8080", true},
+		{"Docker bridge 172.16.x", "172.16.0.1:8080", true},
+		{"Docker bridge 172.31.x", "172.31.255.1:8080", true},
+		{"Private 10.x", "10.0.0.1:8080", true},
+		{"Private 10.255.255.255", "10.255.255.255:8080", true},
+		{"Private 192.168.x", "192.168.1.1:8080", true},
+		{"Private 192.168.0.255", "192.168.0.255:8080", true},
+		{"Public 8.8.8.8", "8.8.8.8:8080", false},
+		{"Public 1.1.1.1", "1.1.1.1:8080", false},
+		{"172.32.x not private", "172.32.0.1:8080", false},
+		{"172.15.x not private", "172.15.0.1:8080", false},
+		{"no port loopback", "127.0.0.1", true},
+		{"no port docker bridge", "172.17.0.1", true},
+		{"no port public", "8.8.8.8", false},
+		{"hostname", "example.com:8080", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTrustedSource(tt.remoteAddr); got != tt.want {
+				t.Errorf("IsTrustedSource(%q) = %v, want %v", tt.remoteAddr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dashboard/dash.go
+++ b/internal/dashboard/dash.go
@@ -71,7 +71,7 @@ func (dash *Dashboard) dashboardSubject(r *http.Request) string {
 	if who.ID != "" {
 		return who.ID
 	}
-	if core.IsLocalhost(r.RemoteAddr) {
+	if core.IsTrustedSource(r.RemoteAddr) {
 		return "__localhost__"
 	}
 	if core.ValidAPIKey(r) {

--- a/internal/proxyproviders/tailscale/provider.go
+++ b/internal/proxyproviders/tailscale/provider.go
@@ -312,6 +312,13 @@ func (c *Client) getOAuth(cfg *model.Config) (string, error) {
 
 	authkey, err := tsclient.Keys().Create(ctx, ckr)
 	if err != nil {
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "invalid or not permitted") {
+			return "", fmt.Errorf(
+				"OAuth token rejected for tags %v — ensure the tag is assigned to your OAuth client in the Tailscale admin console (Access Controls → OAuth clients) and listed in ACL tagOwners. Original error: %w",
+				capabilities.Devices.Create.Tags, err,
+			)
+		}
 		return "", fmt.Errorf("unable to get OAuth token: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes #443 — three issues preventing TSDProxy v2.2.0 from working correctly in Docker deployments.

### Changes

**1. `adminAllowLocalhost` now works with Docker port mapping** (`internal/core/admin.go`)
- The `IsLocalhost()` check only matched loopback addresses (`127.0.0.0/8`, `::1`). Docker port-mapped requests arrive from the bridge gateway (`172.17.0.1`), which never matched.
- Added `IsTrustedSource()` that also accepts RFC 1918 private IPs (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).
- Used in `AdminMiddleware`, `ViewerMiddleware`, `IsAdmin`, and `dashboardSubject`.
- **`IsLocalhost` is preserved unchanged** in `validProxyAuthToken`, `ResolveWhois`, and `StripProxyIdentityHeaders` — these gate header trust and must remain loopback-only.

**2. Docker hostname auto-default** (`internal/config/config.go`)
- When running inside Docker (`/.dockerenv` detection), automatically overrides `http.hostname` from `127.0.0.1` to `0.0.0.0`.
- Eliminates the manual config step that confused users in #443.

**3. Actionable OAuth tag error** (`internal/proxyproviders/tailscale/provider.go`)
- Detects Tailscale `"invalid or not permitted"` 400 errors and surfaces a message pointing users to OAuth client tag assignment in the Tailscale admin console + `tagOwners` ACL configuration.
- The v2.2.0 scope narrowing (`all:write` → `devices:core + auth_keys`) was a breaking change that required OAuth client reconfiguration but gave no guidance.

### Tests
- `admin_test.go`: 30 test cases covering `IsLocalhost` and `IsTrustedSource` with loopback, Docker bridge IPs, private ranges, boundary cases (172.15.x, 172.32.x), public IPs, hostnames, empty strings.

### Security consideration
`IsTrustedSource` expands the trust boundary from loopback-only to private networks. This is gated behind `adminAllowLocalhost` (default `false`, opt-in). The same trade-off already existed — anyone on localhost had admin access; now anyone on the Docker bridge does. In Docker deployments, this is equivalent since Docker NAT makes all port-mapped traffic appear from the bridge gateway.

Closes #443