### PR TITLE
feat(health): add health_check_enabled config option

### DIFF
--- a/docs/content/docs/operations/health-check.md
+++ b/docs/content/docs/operations/health-check.md
@@ -83,6 +83,7 @@ Backend health monitoring can be configured per-provider (Docker or Lists) in
 | Setting | YAML (provider) | Docker Label | Default | Description |
 |---------|-----------------|-------------|---------|-------------|
 | Enable | `autoRestart` | `tsdproxy.auto_restart` | `true` | Enable/disable re-resolution on failure |
+| Enabled | `healthCheckEnabled` | `tsdproxy.health_check_enabled` | `true` | Enable/disable health probes entirely |
 | Interval | `healthCheckInterval` | `tsdproxy.health_check_interval` | `30` | Seconds between health probes |
 | Failures | `healthCheckFailures` | `tsdproxy.health_check_failures` | `3` | Consecutive failures before re-resolution |
 | Cooldown | `healthCheckCooldown` | `tsdproxy.health_check_cooldown` | `0` | Fixed cooldown in seconds (0 = exponential backoff) |

--- a/docs/content/docs/providers/docker-reference.md
+++ b/docs/content/docs/providers/docker-reference.md
@@ -31,6 +31,7 @@ This is the only label you need. TSDProxy will use the container name as the Tai
 | `tsdproxy.tags` | — | Comma-separated Tailscale tags (OAuth only) |
 | `tsdproxy.identity_headers` | `"true"` | Inject identity headers into upstream requests. Set to `"false"` to disable. Client-supplied headers are always stripped. |
 | `tsdproxy.auto_restart` | `"true"` | Enable automatic re-resolution on backend failure |
+| `tsdproxy.health_check_enabled` | `"true"` | Enable health probes. Set to `"false"` to disable all health monitoring for this container |
 | `tsdproxy.health_check_interval` | `"30"` | Seconds between health probes |
 | `tsdproxy.health_check_failures` | `"3"` | Consecutive failures before re-resolution |
 | `tsdproxy.health_check_cooldown` | `"0"` | Fixed cooldown in seconds (0 = exponential backoff) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,7 @@ type (
 		DefaultProxyProvider     string `validate:"omitempty" yaml:"defaultProxyProvider,omitempty"`
 		TryDockerInternalNetwork bool   `validate:"boolean" default:"false" yaml:"tryDockerInternalNetwork"`
 		AutoRestart              bool   `validate:"boolean" default:"true" yaml:"autoRestart"`
+		HealthCheckEnabled       bool   `validate:"boolean" default:"true" yaml:"healthCheckEnabled"`
 		HealthCheckInterval      int    `validate:"numeric,min=1" default:"30" yaml:"healthCheckInterval"`
 		HealthCheckFailures      int    `validate:"numeric,min=1" default:"3" yaml:"healthCheckFailures"`
 		HealthCheckCooldown      int    `validate:"numeric,min=0" default:"0" yaml:"healthCheckCooldown"`
@@ -122,10 +123,11 @@ type (
 		Filename              string `validate:"required,file" yaml:"filename"`
 		DefaultProxyProvider  string `validate:"omitempty" yaml:"defaultProxyProvider,omitempty"`
 		DefaultProxyAccessLog bool   `default:"true" validate:"boolean" yaml:"defaultProxyAccessLog"`
-		AutoRestart           bool   `validate:"boolean" default:"true" yaml:"autoRestart"`
-		HealthCheckInterval   int    `validate:"numeric,min=1" default:"30" yaml:"healthCheckInterval"`
-		HealthCheckFailures   int    `validate:"numeric,min=1" default:"3" yaml:"healthCheckFailures"`
-		HealthCheckCooldown   int    `validate:"numeric,min=0" default:"0" yaml:"healthCheckCooldown"`
+		AutoRestart          bool   `validate:"boolean" default:"true" yaml:"autoRestart"`
+		HealthCheckEnabled   bool   `validate:"boolean" default:"true" yaml:"healthCheckEnabled"`
+		HealthCheckInterval  int    `validate:"numeric,min=1" default:"30" yaml:"healthCheckInterval"`
+		HealthCheckFailures  int    `validate:"numeric,min=1" default:"3" yaml:"healthCheckFailures"`
+		HealthCheckCooldown  int    `validate:"numeric,min=0" default:"0" yaml:"healthCheckCooldown"`
 	}
 )
 

--- a/internal/model/proxyconfig.go
+++ b/internal/model/proxyconfig.go
@@ -24,6 +24,7 @@ type (
 		ProxyAccessLog      bool      `default:"true" validate:"boolean"`
 		IdentityHeaders     bool      `default:"true" validate:"boolean"`
 		AutoRestart         bool      `default:"true" validate:"boolean"`
+		HealthCheckEnabled  bool      `default:"true" validate:"boolean"`
 		HealthCheckInterval int       `default:"30" validate:"numeric,min=1"`
 		HealthCheckFailures int       `default:"3" validate:"numeric,min=1"`
 		HealthCheckCooldown int       `default:"0" validate:"numeric,min=0"`

--- a/internal/proxymanager/proxy.go
+++ b/internal/proxymanager/proxy.go
@@ -335,6 +335,10 @@ func (proxy *Proxy) UnsubscribeLogs(ch chan string) {
 }
 
 func (proxy *Proxy) startHealthChecker() {
+	if !proxy.Config.HealthCheckEnabled {
+		return
+	}
+
 	// NOTE: Only the first non-redirect port (sorted by name) gets a health checker.
 	// If the proxy has multiple ports, only the first one is monitored.
 	keys := make([]string, 0, len(proxy.Config.Ports))

--- a/internal/targetproviders/docker/consts.go
+++ b/internal/targetproviders/docker/consts.go
@@ -29,6 +29,7 @@ const (
 	// Identity / auth header injection (default: enabled)
 	LabelIdentityHeaders     = LabelPrefix + "identity_headers"
 	LabelAutoRestart         = LabelPrefix + "auto_restart"
+	LabelHealthCheckEnabled = LabelPrefix + "health_check_enabled"
 	LabelHealthCheckInterval = LabelPrefix + "health_check_interval"
 	LabelHealthCheckFailures = LabelPrefix + "health_check_failures"
 	LabelHealthCheckCooldown = LabelPrefix + "health_check_cooldown"

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -45,6 +45,8 @@ type (
 		autodetect             bool
 		autoRestart            bool
 		providerAutoRestart    bool
+		healthCheckEnabled     bool
+		providerHealthEnabled  bool
 		healthCheckInterval    int
 		healthCheckFailures    int
 		healthCheckCooldown    int
@@ -83,6 +85,7 @@ func newContainer(logger zerolog.Logger, dcontainer ctypes.InspectResponse, dser
 
 	c.autodetect = c.getLabelBool(LabelAutoDetect, providerAutoDetect)
 	c.autoRestart = c.getLabelBool(LabelAutoRestart, c.providerAutoRestart)
+	c.healthCheckEnabled = c.getLabelBool(LabelHealthCheckEnabled, c.providerHealthEnabled)
 	c.healthCheckInterval = c.getLabelInt(LabelHealthCheckInterval, c.providerHealthInterval, 1, healthCheckMaxIntervalSeconds)
 	c.healthCheckFailures = c.getLabelInt(LabelHealthCheckFailures, c.providerHealthFailures, 1, healthCheckMaxFailures)
 	c.healthCheckCooldown = c.getLabelInt(LabelHealthCheckCooldown, c.providerHealthCooldown, 0, healthCheckMaxCooldownSeconds)
@@ -207,6 +210,7 @@ func (c *container) newProxyConfig() (*model.Config, error) {
 	pcfg.ProxyAccessLog = c.getLabelBool(LabelContainerAccessLog, model.DefaultProxyAccessLog)
 	pcfg.IdentityHeaders = c.getLabelBool(LabelIdentityHeaders, model.DefaultIdentityHeaders)
 	pcfg.AutoRestart = c.autoRestart
+	pcfg.HealthCheckEnabled = c.healthCheckEnabled
 	pcfg.HealthCheckInterval = c.healthCheckInterval
 	pcfg.HealthCheckFailures = c.healthCheckFailures
 	pcfg.HealthCheckCooldown = c.healthCheckCooldown
@@ -546,8 +550,9 @@ func withProviderAutoRestart(autoRestart bool) ContainerOption {
 	}
 }
 
-func withProviderHealthCheck(interval, failures, cooldown int) ContainerOption {
+func withProviderHealthCheck(enabled bool, interval, failures, cooldown int) ContainerOption {
 	return func(c *container) {
+		c.providerHealthEnabled = enabled
 		c.providerHealthInterval = interval
 		c.providerHealthFailures = failures
 		c.providerHealthCooldown = cooldown

--- a/internal/targetproviders/docker/docker.go
+++ b/internal/targetproviders/docker/docker.go
@@ -33,6 +33,7 @@ type (
 		defaultTargetHostname    string
 		host                     string
 		name                     string
+		healthCheckEnabled       bool
 		healthCheckInterval      int
 		healthCheckFailures      int
 		healthCheckCooldown      int
@@ -65,6 +66,7 @@ func New(log zerolog.Logger, name string, provider *config.DockerTargetProviderC
 		defaultProxyProvider:     provider.DefaultProxyProvider,
 		tryDockerInternalNetwork: provider.TryDockerInternalNetwork,
 		autoRestart:              provider.AutoRestart,
+		healthCheckEnabled:       provider.HealthCheckEnabled,
 		healthCheckInterval:      provider.HealthCheckInterval,
 		healthCheckFailures:      provider.HealthCheckFailures,
 		healthCheckCooldown:      provider.HealthCheckCooldown,
@@ -145,7 +147,7 @@ func (c *Client) buildProxyConfig(id string) (*model.Config, *container, error) 
 		withDefaultTargetHostname(c.defaultTargetHostname),
 		withTargetProviderName(c.name),
 		withProviderAutoRestart(c.autoRestart),
-		withProviderHealthCheck(c.healthCheckInterval, c.healthCheckFailures, c.healthCheckCooldown),
+		withProviderHealthCheck(c.healthCheckEnabled, c.healthCheckInterval, c.healthCheckFailures, c.healthCheckCooldown),
 	)
 
 	pcfg, err := ctn.newProxyConfig()

--- a/internal/targetproviders/list/list.go
+++ b/internal/targetproviders/list/list.go
@@ -256,6 +256,7 @@ func (c *Client) buildConfig(id string, p proxyConfig) (*model.Config, error) {
 	pcfg.ProxyAccessLog = model.DefaultProxyAccessLog
 	pcfg.IdentityHeaders = model.DefaultIdentityHeaders
 	pcfg.AutoRestart = c.config.AutoRestart
+	pcfg.HealthCheckEnabled = c.config.HealthCheckEnabled
 	pcfg.HealthCheckInterval = c.config.HealthCheckInterval
 	pcfg.HealthCheckFailures = c.config.HealthCheckFailures
 	pcfg.HealthCheckCooldown = c.config.HealthCheckCooldown


### PR DESCRIPTION
## Summary

Implements #447 — adds a `health_check_enabled` flag to disable health probes per-proxy.

## Changes

- **New config field**: `HealthCheckEnabled` (default: `true`) added to `model.Config`, `DockerTargetProviderConfig`, and `ListTargetProviderConfig`
- **New Docker label**: `tsdproxy.health_check_enabled` — set to `"false"` to disable health monitoring for a container
- **Provider defaults**: Can be set at provider level in `tsdproxy.yaml` (`healthCheckEnabled: false`)
- **List provider**: Inherits from `ListTargetProviderConfig.HealthCheckEnabled`
- **Gate**: `startHealthChecker()` returns early when `HealthCheckEnabled` is `false`
- **Docs**: Updated health-check and docker-label-reference pages

## Usage

### Per-container (Docker label)
```yaml
labels:
  tsdproxy.health_check_enabled: "false"
```

### Provider default (tsdproxy.yaml)
```yaml
docker:
  local:
    healthCheckEnabled: false  # disable for all containers on this provider
```

```yaml
lists:
  critical:
    healthCheckEnabled: false  # disable for all proxies in this list
```

Closes #447