### PR TITLE
feat: Go template support for custom webhook payloads

### DIFF
--- a/docs/content/docs/notifications/generic.md
+++ b/docs/content/docs/notifications/generic.md
@@ -43,6 +43,18 @@ TSDProxy sends a `POST` request with `Content-Type: application/json`:
 | `timestamp` | string | UTC timestamp in RFC 3339 format |
 | `message` | string | Human-readable status change description |
 
+## Custom Payload Template
+
+Set `template` to render a custom request body with Go `text/template`. The template receives the webhook event fields as `.ProxyName`, `.Status`, `.OldStatus`, `.Timestamp`, and `.Message`. When `template` is set and parses successfully, it takes precedence over `type` and is sent as `Content-Type: application/json`.
+
+```yaml {filename="/config/tsdproxy.yaml"}
+webhooks:
+  - url: "https://hooks.slack.com/services/your/webhook/url"
+    type: slack
+    template: |
+      {"text":"TSDProxy: Proxy `{{.ProxyName}}` changed from `{{.OldStatus}}` to `{{.Status}}`"}
+```
+
 ## With Custom Headers
 
 ```yaml {filename="/config/tsdproxy.yaml"}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,10 +72,11 @@ type (
 	}
 
 	WebhookConfig struct {
-		URL     string            `yaml:"url"`
-		Headers map[string]string `yaml:"headers,omitempty"`
-		Type    string            `yaml:"type"`
-		Events  []string          `yaml:"events,omitempty"`
+		URL      string            `yaml:"url"`
+		Headers  map[string]string `yaml:"headers,omitempty"`
+		Type     string            `yaml:"type"`
+		Events   []string          `yaml:"events,omitempty"`
+		Template string            `yaml:"template,omitempty"`
 	}
 
 	// LogConfig stores logging configuration.

--- a/internal/core/webhook/webhook.go
+++ b/internal/core/webhook/webhook.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/almeidapaulopt/tsdproxy/internal/config"
@@ -58,21 +59,23 @@ type (
 	}
 
 	sendJob struct {
+		index int
 		event Event
 		cfg   config.WebhookConfig
 	}
 
 	Sender struct {
-		log     zerolog.Logger
-		ctx     context.Context
-		client  httpclient.Doer
-		cancel  context.CancelFunc
-		queue   chan sendJob
-		configs []config.WebhookConfig
-		wg      sync.WaitGroup
-		closeMu sync.Mutex
-		closed  bool
-		started bool
+		log       zerolog.Logger
+		ctx       context.Context
+		client    httpclient.Doer
+		cancel    context.CancelFunc
+		queue     chan sendJob
+		configs   []config.WebhookConfig
+		templates map[int]*template.Template
+		wg        sync.WaitGroup
+		closeMu   sync.Mutex
+		closed    bool
+		started   bool
 	}
 )
 
@@ -83,14 +86,16 @@ func NewSender(log zerolog.Logger, configs []config.WebhookConfig, doer ...httpc
 	} else {
 		client = &http.Client{Timeout: webhookTimeout}
 	}
+	logger := log.With().Str("module", "webhook").Logger()
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Sender{
-		log:     log.With().Str("module", "webhook").Logger(),
-		client:  client,
-		configs: configs,
-		ctx:     ctx,
-		cancel:  cancel,
-		queue:   make(chan sendJob, webhookQueueSize),
+		log:       logger,
+		client:    client,
+		configs:   configs,
+		templates: parseWebhookTemplates(logger, configs),
+		ctx:       ctx,
+		cancel:    cancel,
+		queue:     make(chan sendJob, webhookQueueSize),
 	}
 	return s
 }
@@ -120,12 +125,34 @@ func NewSyncSender(log zerolog.Logger, configs []config.WebhookConfig, doer ...h
 	} else {
 		client = &http.Client{Timeout: webhookTimeout}
 	}
+	logger := log.With().Str("module", "webhook").Logger()
 	return &Sender{
-		log:     log.With().Str("module", "webhook").Logger(),
-		client:  client,
-		configs: configs,
-		ctx:     context.Background(),
+		log:       logger,
+		client:    client,
+		configs:   configs,
+		templates: parseWebhookTemplates(logger, configs),
+		ctx:       context.Background(),
 	}
+}
+
+func parseWebhookTemplates(log zerolog.Logger, configs []config.WebhookConfig) map[int]*template.Template {
+	templates := make(map[int]*template.Template)
+	for i, cfg := range configs {
+		if cfg.Template == "" {
+			continue
+		}
+		tmpl, err := template.New(fmt.Sprintf("webhook-%d", i)).Parse(cfg.Template)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("url", redactURL(cfg.URL)).
+				Int("index", i).
+				Msg("invalid webhook template, using default payload")
+			continue
+		}
+		templates[i] = tmpl
+	}
+	return templates
 }
 
 func (s *Sender) Close() {
@@ -147,8 +174,8 @@ func (s *Sender) Close() {
 func (s *Sender) worker() {
 	defer s.wg.Done()
 	for job := range s.queue {
-		if err := s.sendWithRetry(job.cfg, job.event); err != nil {
-			s.log.Error().Err(err).Str("url", job.cfg.URL).Msg("webhook delivery failed")
+		if err := s.sendWithRetry(job.index, job.cfg, job.event); err != nil {
+			s.log.Error().Err(err).Str("url", redactURL(job.cfg.URL)).Msg("webhook delivery failed")
 		}
 	}
 }
@@ -160,12 +187,12 @@ func (s *Sender) Send(event Event) {
 	if s.closed {
 		return
 	}
-	for _, cfg := range s.configs {
+	for i, cfg := range s.configs {
 		if !eventMatchesFilter(event, cfg.Events) {
 			continue
 		}
 		select {
-		case s.queue <- sendJob{cfg: cfg, event: event}:
+		case s.queue <- sendJob{index: i, cfg: cfg, event: event}:
 		default:
 			s.log.Warn().Msg("webhook queue full, dropping event")
 		}
@@ -174,11 +201,11 @@ func (s *Sender) Send(event Event) {
 
 func (s *Sender) SendSync(event Event) error {
 	var firstErr error
-	for _, cfg := range s.configs {
+	for i, cfg := range s.configs {
 		if !eventMatchesFilter(event, cfg.Events) {
 			continue
 		}
-		if err := s.sendWithRetry(cfg, event); err != nil && firstErr == nil {
+		if err := s.sendWithRetry(i, cfg, event); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -197,7 +224,7 @@ func eventMatchesFilter(event Event, filter []string) bool {
 	return false
 }
 
-func (s *Sender) sendWithRetry(cfg config.WebhookConfig, event Event) error {
+func (s *Sender) sendWithRetry(index int, cfg config.WebhookConfig, event Event) error {
 	safeURL := redactURL(cfg.URL)
 
 	backoff := time.Second
@@ -208,7 +235,7 @@ func (s *Sender) sendWithRetry(cfg config.WebhookConfig, event Event) error {
 		default:
 		}
 
-		if err := s.sendOne(cfg, event); err != nil {
+		if err := s.sendOne(index, cfg, event); err != nil {
 			s.log.Warn().
 				Err(err).
 				Str("url", safeURL).
@@ -239,19 +266,32 @@ func (s *Sender) sendWithRetry(cfg config.WebhookConfig, event Event) error {
 	return err
 }
 
-func (s *Sender) sendOne(cfg config.WebhookConfig, event Event) error {
+func (s *Sender) sendOne(index int, cfg config.WebhookConfig, event Event) error {
 	var body []byte
 	var contentType string
 
-	switch strings.ToLower(cfg.Type) {
-	case providerDiscord:
-		body, contentType = s.formatDiscord(event)
-	case "slack":
-		body, contentType = s.formatSlack(event)
-	case "ntfy":
-		body, contentType = s.formatNtfy(event)
-	default:
-		body, contentType = s.formatGeneric(event)
+	if tmpl := s.templates[index]; tmpl != nil {
+		var rendered bytes.Buffer
+		if err := tmpl.Execute(&rendered, event); err != nil {
+			s.log.Error().
+				Err(err).
+				Str("url", redactURL(cfg.URL)).
+				Int("index", index).
+				Msg("failed to render webhook template")
+			return fmt.Errorf("error rendering webhook template: %w", err)
+		}
+		body, contentType = rendered.Bytes(), contentTypeJSON
+	} else {
+		switch strings.ToLower(cfg.Type) {
+		case providerDiscord:
+			body, contentType = s.formatDiscord(event)
+		case "slack":
+			body, contentType = s.formatSlack(event)
+		case "ntfy":
+			body, contentType = s.formatNtfy(event)
+		default:
+			body, contentType = s.formatGeneric(event)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(s.ctx, http.MethodPost, cfg.URL, bytes.NewReader(body))

--- a/internal/core/webhook/webhook_test.go
+++ b/internal/core/webhook/webhook_test.go
@@ -564,6 +564,185 @@ func TestSendOne(t *testing.T) {
 	})
 }
 
+func TestSendOneTemplatePayload(t *testing.T) {
+	t.Parallel()
+
+	event := testEvent()
+
+	t.Run("renders slack style template", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			contentType string
+			body        string
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contentType = r.Header.Get("Content-Type")
+			bodyBytes, _ := io.ReadAll(r.Body)
+			body = string(bodyBytes)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:      server.URL,
+			Type:     "slack",
+			Template: `{"text":"Proxy {{.ProxyName}} moved from {{.OldStatus}} to {{.Status}}"}`,
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+		if contentType != contentTypeJSON {
+			t.Errorf("Content-Type = %q, want %q", contentType, contentTypeJSON)
+		}
+		want := `{"text":"Proxy test-proxy moved from Stopped to Running"}`
+		if body != want {
+			t.Errorf("body = %q, want %q", body, want)
+		}
+	})
+
+	t.Run("without template uses type formatter", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			contentType string
+			body        []byte
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contentType = r.Header.Get("Content-Type")
+			body, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{URL: server.URL, Type: "slack"}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+		wantBody, wantContentType := s.formatSlack(event)
+		if contentType != wantContentType {
+			t.Errorf("Content-Type = %q, want %q", contentType, wantContentType)
+		}
+		if !bytes.Equal(body, wantBody) {
+			t.Errorf("body = %q, want %q", string(body), string(wantBody))
+		}
+	})
+
+	t.Run("renders all event fields", func(t *testing.T) {
+		t.Parallel()
+
+		var body []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL: server.URL,
+			Template: `{"proxy":"{{.ProxyName}}","status":"{{.Status}}","oldStatus":"{{.OldStatus}}",` +
+				`"timestamp":"{{.Timestamp}}","message":"{{.Message}}"}`,
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+
+		var decoded map[string]string
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal error: %v", err)
+		}
+		want := map[string]string{
+			"proxy":     event.ProxyName,
+			"status":    event.Status,
+			"oldStatus": event.OldStatus,
+			"timestamp": event.Timestamp,
+			"message":   event.Message,
+		}
+		for key, wantValue := range want {
+			if decoded[key] != wantValue {
+				t.Errorf("%s = %q, want %q", key, decoded[key], wantValue)
+			}
+		}
+	})
+
+	t.Run("invalid template falls back to type formatter", func(t *testing.T) {
+		t.Parallel()
+
+		var (
+			body   []byte
+			logBuf bytes.Buffer
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:      server.URL + "/secret?token=abc",
+			Type:     "generic",
+			Template: "{{",
+		}
+		s := NewSyncSender(zerolog.New(&logBuf), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+
+		var decoded Event
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal error: %v", err)
+		}
+		if decoded != event {
+			t.Errorf("decoded event = %+v, want %+v", decoded, event)
+		}
+
+		logOutput := logBuf.String()
+		if !strings.Contains(logOutput, "invalid webhook template") {
+			t.Errorf("log should mention invalid template, got %q", logOutput)
+		}
+		if !strings.Contains(logOutput, server.URL) {
+			t.Errorf("log should contain redacted URL host, got %q", logOutput)
+		}
+		if strings.Contains(logOutput, "token=abc") {
+			t.Errorf("log should not contain URL query secret, got %q", logOutput)
+		}
+	})
+}
+
+func TestSendOneTemplateExecutionError(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	mock := &callMockDoer{fn: func(_ *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}}
+	cfg := config.WebhookConfig{
+		URL:      "http://example.com/webhook",
+		Type:     "generic",
+		Template: "{{.Missing}}",
+	}
+	s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg}, mock)
+
+	err := s.sendOne(0, cfg, testEvent())
+	if err == nil {
+		t.Fatal("expected template execution error")
+	}
+	if !strings.Contains(err.Error(), "error rendering webhook template") {
+		t.Errorf("error should mention template rendering, got %v", err)
+	}
+	if c := calls.Load(); c != 0 {
+		t.Errorf("expected no HTTP calls after template error, got %d", c)
+	}
+}
+
 func testSendOneGeneric(t *testing.T, event Event) {
 	t.Helper()
 
@@ -595,7 +774,7 @@ func testSendOneGeneric(t *testing.T, event Event) {
 		Headers: map[string]string{"X-Test-Header": "test-value"},
 	}
 
-	if err := s.sendOne(cfg, event); err != nil {
+	if err := s.sendOne(0, cfg, event); err != nil {
 		t.Fatalf("sendOne error: %v", err)
 	}
 	if reqMethod != http.MethodPost {
@@ -633,7 +812,7 @@ func testSendOneDiscord(t *testing.T, event Event) {
 		ctx:    context.Background(),
 	}
 
-	if err := s.sendOne(config.WebhookConfig{URL: server.URL, Type: providerDiscord}, event); err != nil {
+	if err := s.sendOne(0, config.WebhookConfig{URL: server.URL, Type: providerDiscord}, event); err != nil {
 		t.Fatalf("sendOne error: %v", err)
 	}
 	if contentType != contentTypeJSON {
@@ -657,7 +836,7 @@ func testSendOneSlack(t *testing.T, event Event) {
 		ctx:    context.Background(),
 	}
 
-	if err := s.sendOne(config.WebhookConfig{URL: server.URL, Type: "slack"}, event); err != nil {
+	if err := s.sendOne(0, config.WebhookConfig{URL: server.URL, Type: "slack"}, event); err != nil {
 		t.Fatalf("sendOne error: %v", err)
 	}
 	if contentType != contentTypeJSON {
@@ -685,7 +864,7 @@ func testSendOneNtfy(t *testing.T, event Event) {
 		ctx:    context.Background(),
 	}
 
-	if err := s.sendOne(config.WebhookConfig{URL: server.URL, Type: "ntfy"}, event); err != nil {
+	if err := s.sendOne(0, config.WebhookConfig{URL: server.URL, Type: "ntfy"}, event); err != nil {
 		t.Fatalf("sendOne error: %v", err)
 	}
 	if contentType != contentTypeTextPlain {
@@ -712,7 +891,7 @@ func testSendOneCasing(t *testing.T, event Event) {
 		ctx:    context.Background(),
 	}
 
-	if err := s.sendOne(config.WebhookConfig{URL: server.URL, Type: "DISCORD"}, event); err != nil {
+	if err := s.sendOne(0, config.WebhookConfig{URL: server.URL, Type: "DISCORD"}, event); err != nil {
 		t.Fatalf("sendOne error: %v", err)
 	}
 	if contentType != contentTypeJSON {
@@ -735,7 +914,7 @@ func testSendOneErrorStatus(t *testing.T, event Event) {
 		ctx:    context.Background(),
 	}
 
-	err := s.sendOne(config.WebhookConfig{URL: server.URL, Type: "generic"}, event)
+	err := s.sendOne(0, config.WebhookConfig{URL: server.URL, Type: "generic"}, event)
 	if err == nil {
 		t.Fatal("expected error for status 400")
 	}
@@ -768,7 +947,7 @@ func TestSendWithRetry(t *testing.T) {
 			ctx:    context.Background(),
 		}
 
-		if err := s.sendWithRetry(config.WebhookConfig{URL: server.URL, Type: "generic"}, event); err != nil {
+		if err := s.sendWithRetry(0, config.WebhookConfig{URL: server.URL, Type: "generic"}, event); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if c := callCount.Load(); c != 1 {
@@ -795,7 +974,7 @@ func TestSendWithRetry(t *testing.T) {
 			ctx:    context.Background(),
 		}
 
-		if err := s.sendWithRetry(config.WebhookConfig{URL: server.URL, Type: "generic"}, event); err != nil {
+		if err := s.sendWithRetry(0, config.WebhookConfig{URL: server.URL, Type: "generic"}, event); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if c := callCount.Load(); c != 2 {
@@ -819,7 +998,7 @@ func TestSendWithRetry(t *testing.T) {
 			ctx:    context.Background(),
 		}
 
-		err := s.sendWithRetry(config.WebhookConfig{URL: server.URL, Type: "generic"}, event)
+		err := s.sendWithRetry(0, config.WebhookConfig{URL: server.URL, Type: "generic"}, event)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -849,7 +1028,7 @@ func TestSendWithRetry(t *testing.T) {
 			cancel: cancel,
 		}
 
-		err := s.sendWithRetry(config.WebhookConfig{URL: server.URL, Type: "generic"}, event)
+		err := s.sendWithRetry(0, config.WebhookConfig{URL: server.URL, Type: "generic"}, event)
 		if err == nil {
 			t.Fatal("expected error from canceled context")
 		}
@@ -1169,7 +1348,7 @@ func TestSendOne_NetworkError(t *testing.T) {
 		ctx:    context.Background(),
 	}
 
-	err := s.sendOne(config.WebhookConfig{URL: "http://127.0.0.1:1/webhook", Type: "generic"}, testEvent())
+	err := s.sendOne(0, config.WebhookConfig{URL: "http://127.0.0.1:1/webhook", Type: "generic"}, testEvent())
 	if err == nil {
 		t.Fatal("expected error from network failure")
 	}
@@ -1209,7 +1388,7 @@ func TestSendWithRetry_NetworkError_ThenSuccess(t *testing.T) {
 
 	cfg := config.WebhookConfig{URL: "http://example.com/webhook", Type: "generic"}
 
-	err := s.sendWithRetry(cfg, event)
+	err := s.sendWithRetry(0, cfg, event)
 	if err != nil {
 		t.Fatalf("expected success after retry, got: %v", err)
 	}
@@ -1232,7 +1411,7 @@ func TestSendOne_502GatewayError(t *testing.T) {
 		ctx:    context.Background(),
 	}
 
-	err := s.sendOne(config.WebhookConfig{URL: "http://example.com/webhook", Type: "generic"}, testEvent())
+	err := s.sendOne(0, config.WebhookConfig{URL: "http://example.com/webhook", Type: "generic"}, testEvent())
 	if err == nil {
 		t.Fatal("expected error for 502 status")
 	}


### PR DESCRIPTION
## Summary
Adds an optional `template` field to each webhook config so the HTTP request body can be rendered with Go `text/template` against the webhook event data. This lets users target arbitrary endpoints (Slack blocks, Discord embeds, PagerDuty, custom systems) without an external transformer. When no template is set, the existing type-based payload (discord/slack/ntfy/generic) is used, so the change is fully backward compatible.

## Why this matters
Webhook payloads were fixed-format, dispatched by `Type` in `sendOne`, which made integrating with endpoints expecting a specific JSON shape impossible without a middleman. Issue #433 (a maintainer roadmap item) requests a `template` field that renders the request body from the event. Templates are parsed once at sender construction and cached per config index, so per-event sends do not re-parse. Parse failures at load time are logged (with redacted URL) and fall back to the default formatter; render failures at send time are logged and returned as errors handled by the existing retry/worker loop, so a bad template never crashes delivery.

## Testing
- `go test ./internal/config/... ./internal/core/webhook/...` (pass)
- `go build ./internal/config/... ./internal/core/webhook/...` (pass)
- `go vet` and `gofmt` clean
- New tests cover: template happy path (renders `{{.ProxyName}}`/`{{.Status}}`/`{{.OldStatus}}` to JSON), backward compat with no template, all-fields rendering, invalid-template load-time fallback, and template execution-error handling.

Fixes #433
