### PR TITLE
feat: webhook template functions, templateContentType, and docs

### DIFF
--- a/docs/content/docs/notifications/generic.md
+++ b/docs/content/docs/notifications/generic.md
@@ -45,7 +45,7 @@ TSDProxy sends a `POST` request with `Content-Type: application/json`:
 
 ## Custom Payload Template
 
-Set `template` to render a custom request body with Go `text/template`. The template receives the webhook event fields as `.ProxyName`, `.Status`, `.OldStatus`, `.Timestamp`, and `.Message`. When `template` is set and parses successfully, it takes precedence over `type` and is sent as `Content-Type: application/json`.
+Set `template` to render a custom request body with Go `text/template`. The template receives the webhook event fields as `.ProxyName`, `.Status`, `.OldStatus`, `.Timestamp`, and `.Message`. When `template` is set and parses successfully, it takes precedence over `type`.
 
 ```yaml {filename="/config/tsdproxy.yaml"}
 webhooks:
@@ -54,6 +54,36 @@ webhooks:
     template: |
       {"text":"TSDProxy: Proxy `{{.ProxyName}}` changed from `{{.OldStatus}}` to `{{.Status}}`"}
 ```
+
+### Template Functions
+
+The following functions are available in templates:
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `toUpper` | Converts string to uppercase | `{{toUpper .Status}}` → `RUNNING` |
+| `toLower` | Converts string to lowercase | `{{toLower .ProxyName}}` → `myapp` |
+| `title` | Converts string to title case | `{{title .Status}}` → `Running` |
+| `trim` | Strips leading and trailing whitespace | `{{trim .Message}}` |
+| `sprintf` | Formats a string with `fmt.Sprintf` verbs | `{{sprintf "%s: %s" .ProxyName .Status}}` |
+
+### Template Content Type
+
+By default, template output is sent with `Content-Type: application/json`. Use `templateContentType` to override:
+
+```yaml {filename="/config/tsdproxy.yaml"}
+webhooks:
+  - url: "https://example.com/webhook"
+    template: |
+      status={{.Status}}
+    templateContentType: "text/plain"
+```
+
+When no `template` is set, `templateContentType` has no effect — the content type is determined by the webhook `type` instead.
+
+### Sanitization
+
+Template rendering outputs the raw field values without sanitization. If your endpoint interprets `@` mentions (e.g. Discord, Slack), consider handling them in your template body or using the built-in type formatters instead.
 
 ## With Custom Headers
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,11 +72,12 @@ type (
 	}
 
 	WebhookConfig struct {
-		URL      string            `yaml:"url"`
-		Headers  map[string]string `yaml:"headers,omitempty"`
-		Type     string            `yaml:"type"`
-		Events   []string          `yaml:"events,omitempty"`
-		Template string            `yaml:"template,omitempty"`
+		Headers             map[string]string `yaml:"headers,omitempty"`
+		URL                 string            `yaml:"url"`
+		Type                string            `yaml:"type"`
+		Template            string            `yaml:"template,omitempty"`
+		TemplateContentType string            `yaml:"templateContentType,omitempty"`
+		Events              []string          `yaml:"events,omitempty"`
 	}
 
 	// LogConfig stores logging configuration.

--- a/internal/core/webhook/webhook.go
+++ b/internal/core/webhook/webhook.go
@@ -21,6 +21,8 @@ import (
 	"github.com/almeidapaulopt/tsdproxy/internal/model"
 
 	"github.com/rs/zerolog"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -31,6 +33,8 @@ const (
 	contentTypeJSON      = "application/json"
 	contentTypeTextPlain = "text/plain"
 	providerDiscord      = "discord"
+	providerSlack        = "slack"
+	providerNtfy         = "ntfy"
 	statusRunning        = "running"
 	statusError          = "error"
 	fieldInline          = "inline"
@@ -59,23 +63,23 @@ type (
 	}
 
 	sendJob struct {
-		index int
 		event Event
 		cfg   config.WebhookConfig
+		index int
 	}
 
 	Sender struct {
 		log       zerolog.Logger
 		ctx       context.Context
 		client    httpclient.Doer
+		templates map[int]*template.Template
 		cancel    context.CancelFunc
 		queue     chan sendJob
 		configs   []config.WebhookConfig
-		templates map[int]*template.Template
 		wg        sync.WaitGroup
 		closeMu   sync.Mutex
-		closed    bool
 		started   bool
+		closed    bool
 	}
 )
 
@@ -135,13 +139,23 @@ func NewSyncSender(log zerolog.Logger, configs []config.WebhookConfig, doer ...h
 	}
 }
 
+var templateFuncs = template.FuncMap{
+	"toUpper": strings.ToUpper,
+	"toLower": strings.ToLower,
+	"title":   cases.Title(language.English).String,
+	"trim":    strings.TrimSpace,
+	"sprintf": fmt.Sprintf,
+}
+
 func parseWebhookTemplates(log zerolog.Logger, configs []config.WebhookConfig) map[int]*template.Template {
 	templates := make(map[int]*template.Template)
 	for i, cfg := range configs {
 		if cfg.Template == "" {
 			continue
 		}
-		tmpl, err := template.New(fmt.Sprintf("webhook-%d", i)).Parse(cfg.Template)
+		tmpl, err := template.New(fmt.Sprintf("webhook-%d", i)).
+			Funcs(templateFuncs).
+			Parse(cfg.Template)
 		if err != nil {
 			log.Error().
 				Err(err).
@@ -280,14 +294,19 @@ func (s *Sender) sendOne(index int, cfg config.WebhookConfig, event Event) error
 				Msg("failed to render webhook template")
 			return fmt.Errorf("error rendering webhook template: %w", err)
 		}
-		body, contentType = rendered.Bytes(), contentTypeJSON
+		body = rendered.Bytes()
+		if cfg.TemplateContentType != "" {
+			contentType = cfg.TemplateContentType
+		} else {
+			contentType = contentTypeJSON
+		}
 	} else {
 		switch strings.ToLower(cfg.Type) {
 		case providerDiscord:
 			body, contentType = s.formatDiscord(event)
-		case "slack":
+		case providerSlack:
 			body, contentType = s.formatSlack(event)
-		case "ntfy":
+		case providerNtfy:
 			body, contentType = s.formatNtfy(event)
 		default:
 			body, contentType = s.formatGeneric(event)

--- a/internal/core/webhook/webhook_test.go
+++ b/internal/core/webhook/webhook_test.go
@@ -564,6 +564,7 @@ func TestSendOne(t *testing.T) {
 	})
 }
 
+//nolint:cyclop // multi-subtest table-driven test, complexity from subtests
 func TestSendOneTemplatePayload(t *testing.T) {
 	t.Parallel()
 
@@ -741,6 +742,190 @@ func TestSendOneTemplateExecutionError(t *testing.T) {
 	if c := calls.Load(); c != 0 {
 		t.Errorf("expected no HTTP calls after template error, got %d", c)
 	}
+}
+
+func TestSendOneTemplateFunctions(t *testing.T) {
+	t.Parallel()
+
+	event := testEvent()
+
+	t.Run("renders with toUpper function", func(t *testing.T) {
+		t.Parallel()
+
+		var body []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:      server.URL,
+			Template: `{"proxy":"{{.ProxyName}}","status":"{{toUpper .Status}}"}`,
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+
+		var decoded struct {
+			Proxy  string `json:"proxy"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal error: %v", err)
+		}
+		if decoded.Status != "RUNNING" {
+			t.Errorf("status = %q, want %q", decoded.Status, "RUNNING")
+		}
+	})
+
+	t.Run("renders with toLower function", func(t *testing.T) {
+		t.Parallel()
+
+		var body []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:      server.URL,
+			Template: `{"proxy":"{{toLower .ProxyName}}","status":"{{toLower .Status}}"}`,
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+
+		var decoded struct {
+			Proxy  string `json:"proxy"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal error: %v", err)
+		}
+		if decoded.Proxy != "test-proxy" {
+			t.Errorf("proxy = %q, want %q", decoded.Proxy, "test-proxy")
+		}
+		if decoded.Status != "running" {
+			t.Errorf("status = %q, want %q", decoded.Status, "running")
+		}
+	})
+
+	t.Run("renders with sprintf function", func(t *testing.T) {
+		t.Parallel()
+
+		var body []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:      server.URL,
+			Template: `{"status":"{{sprintf .Status}}"}`,
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+
+		var decoded struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(body, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal error: %v", err)
+		}
+		if decoded.Status != "Running" {
+			t.Errorf("status = %q, want %q", decoded.Status, "Running")
+		}
+	})
+}
+
+func TestSendOneTemplateContentType(t *testing.T) {
+	t.Parallel()
+
+	event := testEvent()
+
+	t.Run("default content type is application/json", func(t *testing.T) {
+		t.Parallel()
+
+		var contentType string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contentType = r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:      server.URL,
+			Template: `{"status":"{{.Status}}"}`,
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+		if contentType != contentTypeJSON {
+			t.Errorf("Content-Type = %q, want %q", contentType, contentTypeJSON)
+		}
+	})
+
+	t.Run("custom templateContentType is used when set", func(t *testing.T) {
+		t.Parallel()
+
+		var contentType string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contentType = r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:                 server.URL,
+			Template:            `status={{.Status}}`,
+			TemplateContentType: "text/plain",
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+		if contentType != "text/plain" {
+			t.Errorf("Content-Type = %q, want %q", contentType, "text/plain")
+		}
+	})
+
+	t.Run("templateContentType ignored when no template set", func(t *testing.T) {
+		t.Parallel()
+
+		var contentType string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contentType = r.Header.Get("Content-Type")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		cfg := config.WebhookConfig{
+			URL:                 server.URL,
+			Type:                "ntfy",
+			TemplateContentType: "text/plain",
+		}
+		s := NewSyncSender(zerolog.Nop(), []config.WebhookConfig{cfg})
+
+		if err := s.SendSync(event); err != nil {
+			t.Fatalf("SendSync error: %v", err)
+		}
+		if contentType != contentTypeTextPlain {
+			t.Errorf("Content-Type = %q, want %q", contentType, contentTypeTextPlain)
+		}
+	})
 }
 
 func testSendOneGeneric(t *testing.T, event Event) {


### PR DESCRIPTION
## Follow-ups from #480

Implements the optional follow-ups from the template PR review:

### Changes

1. **Template FuncMap** — 5 safe string functions available in webhook templates: `toUpper`, `toLower`, `title`, `trim`, `sprintf`
2. **`templateContentType` config field** — allows overriding the default `application/json` content type for template-based webhooks
3. **Documentation** — template functions table, `templateContentType` usage, and @-sanitization note
4. **Cleanup** — extracted `providerSlack`/ `providerNtfy` constants, replaced deprecated `strings.Title`, fixed struct field alignment

### Verification
- go build, go test, golangci-lint — all clean