### PR TITLE
feat: round-robin load balancing for HTTP/HTTPS ports

### DIFF
--- a/docs/content/docs/advanced/roadmap.md
+++ b/docs/content/docs/advanced/roadmap.md
@@ -8,16 +8,14 @@ Ideas for future TSDProxy features, ordered by effort.
 
 ## Multi-Target Load Balancing
 
-**Status**: Code-ready. `PortConfig.targets` is `[]*url.URL` — the struct
-supports multiple backends but only the first is used today. Adding
-round-robin across targets would be a small change in the proxy handler.
+**Status**: Phase 1 shipped. HTTP/HTTPS ports can round-robin across
+list-provider targets with `loadBalance: roundrobin`. Remaining work is
+TCP/UDP support and health-aware target selection.
 
 ```yaml
-# Proposed config
-tsdproxy.port.1: "443/https:80/http,80/http,80/http"
-# or in lists:
 ports:
   443/https:
+    loadBalance: roundrobin
     targets:
       - http://backend1:8080
       - http://backend2:8080

--- a/docs/content/docs/providers/docker-reference.md
+++ b/docs/content/docs/providers/docker-reference.md
@@ -93,6 +93,10 @@ Append these after a comma to any proxy port config:
 | `no_tlsvalidate` | Disable TLS certificate validation on the target |
 | `tailscale_funnel` | Expose the port publicly via Tailscale Funnel |
 | `no_autodetect` | Disable auto-detection of the target URL for this port |
+| `loadbalance=first\|roundrobin` | Select the target load-balancing strategy (`first` by default) |
+
+> [!NOTE]
+> The Docker provider currently discovers one target per port, so `loadbalance` is forward-compatible only and has no effect today. Round-robin currently works via the list provider.
 
 ### Common Patterns
 

--- a/docs/content/docs/providers/docker.md
+++ b/docs/content/docs/providers/docker.md
@@ -141,6 +141,10 @@ labels:
 | `no_tlsvalidate` | Disable TLS validation on the target certificate (TLS validation is enabled by default) |
 | `tailscale_funnel` | Activate Tailscale Funnel on the port |
 | `no_autodetect` | Disable auto-detection of the target URL for this port |
+| `loadbalance=first\|roundrobin` | Select the target load-balancing strategy (`first` by default) |
+
+> [!NOTE]
+> The Docker provider currently discovers one target per port, so `loadbalance` is forward-compatible only and has no effect today. Round-robin currently works via the list provider.
 
 ## Port ranges
 

--- a/docs/content/docs/providers/lists.md
+++ b/docs/content/docs/providers/lists.md
@@ -125,7 +125,8 @@ proxyname: # Name of the proxy
 
   ports:
     port/protocol: #example 443/https, 80/http, 22/tcp, 56000-56002/udp
-    targets: # list of targets (in this version only the first will be used)
+    loadBalance: roundrobin # (optional) (defaults to "first") "first" or "roundrobin"
+    targets: # all targets are used with roundrobin; first target only by default
       - http://sub.domain.com:8111 # change to your target
     tailscale: # (optional)
       funnel: true # (optional) (defaults to false), enable funnel mode
@@ -137,6 +138,9 @@ proxyname: # Name of the proxy
     label: "" # (optional), label to be shown in dashboard
     icon: "" # (optional), icon to be shown in dashboard
 ```
+
+> [!WARNING]
+> Round-robin is available only for HTTP/HTTPS ports and is not health-aware yet; unhealthy backends can still receive traffic.
 
 > [!TIP]
 > TSDProxy will reload the proxy list when it is updated.

--- a/internal/model/port.go
+++ b/internal/model/port.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 type (
@@ -20,6 +21,7 @@ type (
 		ProxyPort     int           `validate:"hostname_port" yaml:"proxyPort"`
 		TLSValidate   bool          `validate:"boolean" yaml:"tlsValidate"`
 		NoAutoDetect  bool          `validate:"boolean" yaml:"noAutoDetect"`
+		LoadBalance   string        `validate:"string" yaml:"loadBalance"`
 		IsRedirect    bool          `validate:"boolean" yaml:"isRedirect"`
 		Tailscale     TailscalePort `validate:"dive" yaml:"tailscale"`
 	}
@@ -29,8 +31,9 @@ type (
 	}
 
 	targetState struct {
-		targets []*url.URL
-		mtx     sync.RWMutex
+		targets   []*url.URL
+		nextIndex atomic.Uint64
+		mtx       sync.RWMutex
 	}
 )
 
@@ -52,6 +55,9 @@ const (
 
 	DNSProviderCloudflare = "cloudflare"
 	DNSProviderMagicDNS   = "magicdns"
+
+	LoadBalanceFirst      = "first"
+	LoadBalanceRoundRobin = "roundrobin"
 
 	rangeKeyPrefix = "range_0"
 )
@@ -151,6 +157,7 @@ func defaultPortConfig(name string) PortConfig {
 		ProxyProtocol: ProtoHTTPS,
 		ProxyPort:     defaultProxyPort,
 		TLSValidate:   DefaultTLSValidate,
+		LoadBalance:   LoadBalanceFirst,
 		IsRedirect:    false,
 		targets:       &targetState{},
 	}
@@ -263,6 +270,24 @@ func (p *PortConfig) GetFirstTarget() *url.URL {
 	return p.targets.getFirst()
 }
 
+func (p *PortConfig) SelectTarget(strategy string) *url.URL {
+	if p.targets == nil {
+		return nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(strategy)) {
+	case "", LoadBalanceFirst:
+		return p.targets.getFirst()
+	case LoadBalanceRoundRobin:
+		if p.targets.count() <= 1 {
+			return p.targets.getFirst()
+		}
+		return p.targets.next()
+	default:
+		return p.targets.getFirst()
+	}
+}
+
 func (p *PortConfig) GetFirstTargetString() string {
 	t := p.GetFirstTarget()
 	if t == nil {
@@ -301,9 +326,35 @@ func (ts *targetState) getFirst() *url.URL {
 	if len(ts.targets) == 0 {
 		return nil
 	}
+	return cloneTargetURL(ts.targets[0])
+}
+
+func (ts *targetState) next() *url.URL {
+	ts.mtx.RLock()
+	defer ts.mtx.RUnlock()
+	if len(ts.targets) == 0 {
+		return nil
+	}
+	if len(ts.targets) == 1 {
+		return cloneTargetURL(ts.targets[0])
+	}
+	idx := ts.nextIndex.Add(1) - 1
+	return cloneTargetURL(ts.targets[idx%uint64(len(ts.targets))])
+}
+
+func (ts *targetState) count() int {
+	ts.mtx.RLock()
+	defer ts.mtx.RUnlock()
+	return len(ts.targets)
+}
+
+func cloneTargetURL(target *url.URL) *url.URL {
+	if target == nil {
+		return nil
+	}
 	// Deep copy via round-trip through Parse to avoid sharing pointer fields
 	// (e.g. url.User) with the stored target.
-	cp, _ := url.Parse(ts.targets[0].String())
+	cp, _ := url.Parse(target.String())
 	if cp == nil {
 		return nil
 	}

--- a/internal/model/port.go
+++ b/internal/model/port.go
@@ -18,10 +18,10 @@ type (
 		targets       *targetState
 		name          string        `validate:"string" yaml:"name"`
 		ProxyProtocol string        `validate:"string" yaml:"proxyProtocol"`
+		LoadBalance   string        `validate:"string" yaml:"loadBalance"`
 		ProxyPort     int           `validate:"hostname_port" yaml:"proxyPort"`
 		TLSValidate   bool          `validate:"boolean" yaml:"tlsValidate"`
 		NoAutoDetect  bool          `validate:"boolean" yaml:"noAutoDetect"`
-		LoadBalance   string        `validate:"string" yaml:"loadBalance"`
 		IsRedirect    bool          `validate:"boolean" yaml:"isRedirect"`
 		Tailscale     TailscalePort `validate:"dive" yaml:"tailscale"`
 	}

--- a/internal/model/port.go
+++ b/internal/model/port.go
@@ -31,7 +31,8 @@ type (
 	}
 
 	targetState struct {
-		targets   []*url.URL
+		targets []*url.URL
+		// nextIndex is not reset when targets change, so replacement may shift the rotation phase.
 		nextIndex atomic.Uint64
 		mtx       sync.RWMutex
 	}
@@ -270,6 +271,10 @@ func (p *PortConfig) GetFirstTarget() *url.URL {
 	return p.targets.getFirst()
 }
 
+// SelectTarget returns a target according to strategy. Round-robin is not
+// health-aware in this phase: only the first target is health-checked, so
+// unhealthy backends at index 1 or later still receive traffic. Health-aware
+// selection is deferred to Phase 1.5.
 func (p *PortConfig) SelectTarget(strategy string) *url.URL {
 	if p.targets == nil {
 		return nil

--- a/internal/model/port_test.go
+++ b/internal/model/port_test.go
@@ -282,6 +282,122 @@ func TestPortConfig_GetFirstTargetString_Empty(t *testing.T) {
 	}
 }
 
+func TestPortConfig_SelectTarget_RoundRobin(t *testing.T) {
+	cfg := PortConfig{}
+	for _, raw := range []string{
+		"http://backend-0:8080",
+		"http://backend-1:8080",
+		"http://backend-2:8080",
+	} {
+		cfg.AddTarget(urlMustParse(raw))
+	}
+
+	for i, want := range []string{
+		"backend-0:8080",
+		"backend-1:8080",
+		"backend-2:8080",
+		"backend-0:8080",
+	} {
+		target := cfg.SelectTarget(LoadBalanceRoundRobin)
+		if target == nil {
+			t.Fatalf("call %d: got nil target", i)
+		}
+		if target.Host != want {
+			t.Errorf("call %d: got host %q, want %q", i, target.Host, want)
+		}
+	}
+}
+
+func TestPortConfig_SelectTarget_SingleTargetAlwaysFirst(t *testing.T) {
+	cfg := PortConfig{}
+	cfg.AddTarget(urlMustParse("http://backend:8080"))
+
+	for i := 0; i < 3; i++ {
+		target := cfg.SelectTarget(LoadBalanceRoundRobin)
+		if target == nil {
+			t.Fatalf("call %d: got nil target", i)
+		}
+		if target.Host != "backend:8080" {
+			t.Errorf("call %d: got host %q, want backend:8080", i, target.Host)
+		}
+	}
+}
+
+func TestPortConfig_SelectTarget_EmptyTargets(t *testing.T) {
+	cfg := PortConfig{}
+	if target := cfg.SelectTarget(LoadBalanceRoundRobin); target != nil {
+		t.Errorf("empty config: got %v, want nil", target)
+	}
+}
+
+func TestPortConfig_SelectTarget_UnknownStrategyDefaultsToFirst(t *testing.T) {
+	cfg := PortConfig{}
+	cfg.AddTarget(urlMustParse("http://backend-0:8080"))
+	cfg.AddTarget(urlMustParse("http://backend-1:8080"))
+
+	for i := 0; i < 3; i++ {
+		target := cfg.SelectTarget("unknown")
+		if target == nil {
+			t.Fatalf("call %d: got nil target", i)
+		}
+		if target.Host != "backend-0:8080" {
+			t.Errorf("call %d: got host %q, want backend-0:8080", i, target.Host)
+		}
+	}
+}
+
+func TestPortConfig_SelectTarget_ReturnsDeepCopy(t *testing.T) {
+	cfg := PortConfig{}
+	cfg.AddTarget(urlMustParse("http://backend-0:8080"))
+	cfg.AddTarget(urlMustParse("http://backend-1:8080"))
+
+	target := cfg.SelectTarget(LoadBalanceRoundRobin)
+	if target == nil {
+		t.Fatal("got nil target")
+	}
+	target.Host = "mutated:8080"
+
+	_ = cfg.SelectTarget(LoadBalanceRoundRobin)
+	target = cfg.SelectTarget(LoadBalanceRoundRobin)
+	if target == nil {
+		t.Fatal("got nil target after mutation")
+	}
+	if target.Host != "backend-0:8080" {
+		t.Errorf("stored target was mutated: got host %q, want backend-0:8080", target.Host)
+	}
+}
+
+func TestPortConfig_SelectTarget_ConcurrentRoundRobin(t *testing.T) {
+	cfg := PortConfig{}
+	for _, raw := range []string{
+		"http://backend-0:8080",
+		"http://backend-1:8080",
+		"http://backend-2:8080",
+	} {
+		cfg.AddTarget(urlMustParse(raw))
+	}
+
+	var nilCount int64
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				target := cfg.SelectTarget(LoadBalanceRoundRobin)
+				if target == nil {
+					atomic.AddInt64(&nilCount, 1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&nilCount); got != 0 {
+		t.Errorf("SelectTarget returned nil %d times", got)
+	}
+}
+
 func TestPortConfig_ReplaceTarget(t *testing.T) {
 	cfg, _ := NewPortLongLabel("443/https:80/http")
 

--- a/internal/proxymanager/port_http.go
+++ b/internal/proxymanager/port_http.go
@@ -177,7 +177,7 @@ func proxyRewrite(
 	proxyAuthToken string,
 ) func(r *httputil.ProxyRequest) {
 	return func(r *httputil.ProxyRequest) {
-		target := pconfig.GetFirstTarget()
+		target := pconfig.SelectTarget(pconfig.LoadBalance)
 		if target != nil {
 			r.SetURL(target)
 		}
@@ -210,8 +210,10 @@ func proxyRewrite(
 				// Forward the auth token only to the internal management
 				// server (self-proxy case).  Never expose it to external
 				// backends — a leaked token allows identity spoofing on
-				// the management API.
-				if isManagementTarget(pconfig.GetFirstTarget(), httpPortStr) {
+				// the management API. Check the target selected for THIS
+				// request (round-robin may route to a non-management backend
+				// even when the first target is the self-proxy).
+				if isManagementTarget(target, httpPortStr) {
 					r.Out.Header.Set(consts.HeaderAuthToken, proxyAuthToken)
 				}
 			}

--- a/internal/proxymanager/port_http_token_test.go
+++ b/internal/proxymanager/port_http_token_test.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Paulo Almeida <almeidapaulopt@gmail.com>
+// SPDX-License-Identifier: MIT
+
+package proxymanager
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"testing"
+
+	"github.com/almeidapaulopt/tsdproxy/internal/consts"
+	"github.com/almeidapaulopt/tsdproxy/internal/model"
+)
+
+func TestProxyRewriteRoundRobinManagementTokenIsolation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		managementPort = "8080"
+		authToken      = "management-token"
+	)
+
+	pconfig := model.PortConfig{
+		ProxyProtocol: model.ProtoHTTP,
+		LoadBalance:   model.LoadBalanceRoundRobin,
+	}
+	pconfig.AddTarget(urlMustParse(t, "http://127.0.0.1:"+managementPort))
+	pconfig.AddTarget(urlMustParse(t, "http://backend:8080"))
+
+	rewrite := proxyRewrite(pconfig, true, managementPort, authToken)
+	tests := []struct {
+		name      string
+		wantHost  string
+		wantToken string
+	}{
+		{name: "management target receives token", wantHost: "127.0.0.1:8080", wantToken: authToken},
+		{name: "non-management target does not receive token", wantHost: "backend:8080"},
+	}
+
+	for _, tc := range tests {
+		in := httptest.NewRequest(http.MethodGet, "http://proxy.local/path", nil)
+		in = in.WithContext(model.WhoisNewContext(in.Context(), model.Whois{ID: "user-1"}))
+		out := in.Clone(in.Context())
+		rewrite(&httputil.ProxyRequest{In: in, Out: out})
+
+		if out.URL.Host != tc.wantHost {
+			t.Errorf("%s: got upstream host %q, want %q", tc.name, out.URL.Host, tc.wantHost)
+		}
+		if got := out.Header.Get(consts.HeaderAuthToken); got != tc.wantToken {
+			t.Errorf("%s: got auth token %q, want %q", tc.name, got, tc.wantToken)
+		}
+	}
+}

--- a/internal/proxymanager/port_test.go
+++ b/internal/proxymanager/port_test.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
 	"sync"
 	"testing"
@@ -34,6 +35,15 @@ func newTestTCPConfig(t *testing.T, targetAddr string) model.PortConfig {
 	}
 	pconfig.AddTarget(targetURL)
 	return pconfig
+}
+
+func urlMustParse(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+	targetURL, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse URL %q: %v", rawURL, err)
+	}
+	return targetURL
 }
 
 func startEchoBackend(t *testing.T) (net.Listener, *sync.WaitGroup) {
@@ -383,6 +393,34 @@ func TestPortProxyForwardedProtoHTTP(t *testing.T) {
 	hdr := runPortProxyProtoTest(t, model.ProtoHTTP)
 	if got := hdr.Get("X-Forwarded-Proto"); got != "http" {
 		t.Errorf("X-Forwarded-Proto: want http, got %q", got)
+	}
+}
+
+func TestProxyRewriteRoundRobinDistribution(t *testing.T) {
+	t.Parallel()
+
+	pconfig := model.PortConfig{
+		ProxyProtocol: model.ProtoHTTP,
+		LoadBalance:   model.LoadBalanceRoundRobin,
+	}
+	pconfig.AddTarget(urlMustParse(t, "http://backend-0:8080"))
+	pconfig.AddTarget(urlMustParse(t, "http://backend-1:8080"))
+
+	rewrite := proxyRewrite(pconfig, false, "", "")
+
+	for i, want := range []string{
+		"backend-0:8080",
+		"backend-1:8080",
+		"backend-0:8080",
+		"backend-1:8080",
+	} {
+		in := httptest.NewRequest(http.MethodGet, "http://proxy.local/path", nil)
+		out := in.Clone(in.Context())
+		rewrite(&httputil.ProxyRequest{In: in, Out: out})
+
+		if out.URL.Host != want {
+			t.Errorf("request %d: got upstream host %q, want %q", i, out.URL.Host, want)
+		}
 	}
 }
 

--- a/internal/targetproviders/docker/consts.go
+++ b/internal/targetproviders/docker/consts.go
@@ -18,6 +18,7 @@ const (
 	LabelContainerAccessLog = LabelPrefix + "containeraccesslog"
 	LabelProxyProvider      = LabelPrefix + "proxyprovider"
 	LabelPort               = LabelPrefix + "port."
+	LabelLoadBalance        = LabelPrefix + "loadbalance"
 	// Tailscale
 	LabelEphemeral    = LabelPrefix + "ephemeral"
 	LabelRunWebClient = LabelPrefix + "runwebclient"
@@ -71,4 +72,5 @@ const (
 	PortOptionNoTLSValidate   = "no_tlsvalidate"
 	PortOptionTailscaleFunnel = "tailscale_funnel"
 	PortOptionNoAutoDetect    = "no_autodetect"
+	PortOptionLoadBalance     = "loadbalance"
 )

--- a/internal/targetproviders/docker/container.go
+++ b/internal/targetproviders/docker/container.go
@@ -307,6 +307,18 @@ func (c *container) getPorts(ctx context.Context) model.PortConfigList {
 func (c *container) applyPortOptions(labelKey string, port *model.PortConfig, options []string) {
 	for _, opt := range options {
 		opt = strings.TrimSpace(opt)
+		if strings.HasPrefix(opt, PortOptionLoadBalance+"=") {
+			strategy := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(opt, PortOptionLoadBalance+"=")))
+			switch strategy {
+			case model.LoadBalanceFirst, model.LoadBalanceRoundRobin:
+				port.LoadBalance = strategy
+			default:
+				c.log.Warn().Str("option", opt).Str("port", labelKey).Str("strategy", strategy).
+					Msg("unknown loadbalance strategy; defaulting to first")
+				port.LoadBalance = model.LoadBalanceFirst
+			}
+			continue
+		}
 		switch opt {
 		case PortOptionNoTLSValidate:
 			if !c.allowTLSValidateDisable {
@@ -326,7 +338,7 @@ func (c *container) applyPortOptions(labelKey string, port *model.PortConfig, op
 			port.NoAutoDetect = true
 		default:
 			c.log.Warn().Str("option", opt).Str("port", labelKey).
-				Msg("unrecognized port option (valid: no_tlsvalidate, tailscale_funnel, no_autodetect)")
+				Msg("unrecognized port option (valid: no_tlsvalidate, tailscale_funnel, no_autodetect, loadbalance=first|roundrobin)")
 		}
 	}
 }

--- a/internal/targetproviders/docker/utils_test.go
+++ b/internal/targetproviders/docker/utils_test.go
@@ -278,6 +278,27 @@ func TestApplyPortOptions(t *testing.T) {
 			t.Error("expected TLSValidate=false after trimming whitespace")
 		}
 	})
+
+	loadBalanceTests := []struct {
+		name string
+		opt  string
+		want string
+	}{
+		{name: "loadbalance first", opt: "loadbalance=first", want: model.LoadBalanceFirst},
+		{name: "loadbalance roundrobin", opt: "loadbalance=roundrobin", want: model.LoadBalanceRoundRobin},
+		{name: "loadbalance uppercase roundrobin", opt: "loadbalance=ROUNDROBIN", want: model.LoadBalanceRoundRobin},
+		{name: "invalid loadbalance defaults to first", opt: "loadbalance=bogus", want: model.LoadBalanceFirst},
+	}
+	for _, tc := range loadBalanceTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			port := model.PortConfig{}
+			c.applyPortOptions("port.test", &port, []string{tc.opt})
+			if port.LoadBalance != tc.want {
+				t.Errorf("expected LoadBalance=%q, got %q", tc.want, port.LoadBalance)
+			}
+		})
+	}
 }
 
 func TestApplyPortOptions_OperatorGated(t *testing.T) {

--- a/internal/targetproviders/list/list.go
+++ b/internal/targetproviders/list/list.go
@@ -49,9 +49,9 @@ type (
 	}
 
 	port struct {
+		LoadBalance string              `yaml:"loadBalance"`
 		Targets     []string            `yaml:"targets,omitempty"`
 		Tailscale   model.TailscalePort `validate:"dive" yaml:"tailscale"`
-		LoadBalance string              `yaml:"loadBalance"`
 		IsRedirect  bool                `default:"false" validate:"boolean" yaml:"isRedirect,omitempty"`
 		TLSValidate bool                `validate:"boolean" default:"true" yaml:"tlsValidate"`
 	}
@@ -77,8 +77,8 @@ type (
 	}
 
 	PortAPI struct {
-		Targets     []string         `yaml:"targets"`
 		LoadBalance string           `yaml:"loadBalance,omitempty"`
+		Targets     []string         `yaml:"targets"`
 		TLSValidate bool             `yaml:"tlsValidate"`
 		IsRedirect  bool             `yaml:"isRedirect,omitempty"`
 		Tailscale   TailscalePortAPI `yaml:"tailscale,omitempty"`

--- a/internal/targetproviders/list/list.go
+++ b/internal/targetproviders/list/list.go
@@ -51,6 +51,7 @@ type (
 	port struct {
 		Targets     []string            `yaml:"targets,omitempty"`
 		Tailscale   model.TailscalePort `validate:"dive" yaml:"tailscale"`
+		LoadBalance string              `yaml:"loadBalance"`
 		IsRedirect  bool                `default:"false" validate:"boolean" yaml:"isRedirect,omitempty"`
 		TLSValidate bool                `validate:"boolean" default:"true" yaml:"tlsValidate"`
 	}
@@ -77,6 +78,7 @@ type (
 
 	PortAPI struct {
 		Targets     []string         `yaml:"targets"`
+		LoadBalance string           `yaml:"loadBalance,omitempty"`
 		TLSValidate bool             `yaml:"tlsValidate"`
 		IsRedirect  bool             `yaml:"isRedirect,omitempty"`
 		Tailscale   TailscalePortAPI `yaml:"tailscale,omitempty"`
@@ -398,6 +400,7 @@ func (c *Client) processPortRange(ports model.PortConfigList, k string, v port) 
 
 		cfg.TLSValidate = v.TLSValidate
 		cfg.Tailscale = v.Tailscale
+		cfg.LoadBalance = v.LoadBalance
 
 		expandedKey := k + "." + rangeKey
 		ports[expandedKey] = cfg
@@ -419,6 +422,7 @@ func (c *Client) processSinglePort(ports model.PortConfigList, k string, v port)
 
 	port.TLSValidate = v.TLSValidate
 	port.Tailscale = v.Tailscale
+	port.LoadBalance = v.LoadBalance
 
 	ports[k] = port
 }

--- a/internal/targetproviders/list/list.go
+++ b/internal/targetproviders/list/list.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/url"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/almeidapaulopt/tsdproxy/internal/config"
@@ -383,6 +384,18 @@ func (c *Client) getPorts(l map[string]port) model.PortConfigList {
 	return ports
 }
 
+func (c *Client) normalizeLoadBalance(portKey, raw string) string {
+	strategy := strings.ToLower(strings.TrimSpace(raw))
+	switch strategy {
+	case "", model.LoadBalanceFirst, model.LoadBalanceRoundRobin:
+		return strategy
+	default:
+		c.log.Warn().Str("port", portKey).Str("strategy", strategy).
+			Msg("unknown loadbalance strategy; defaulting to first")
+		return model.LoadBalanceFirst
+	}
+}
+
 func (c *Client) processPortRange(ports model.PortConfigList, k string, v port) {
 	expanded, err := model.ExpandPortRangeShortLabel(k)
 	if err != nil {
@@ -390,6 +403,7 @@ func (c *Client) processPortRange(ports model.PortConfigList, k string, v port) 
 		return
 	}
 
+	loadBalance := c.normalizeLoadBalance(k, v.LoadBalance)
 	for rangeKey, portCfg := range expanded {
 		cfg := portCfg
 		cfg.IsRedirect = v.IsRedirect
@@ -400,7 +414,7 @@ func (c *Client) processPortRange(ports model.PortConfigList, k string, v port) 
 
 		cfg.TLSValidate = v.TLSValidate
 		cfg.Tailscale = v.Tailscale
-		cfg.LoadBalance = v.LoadBalance
+		cfg.LoadBalance = loadBalance
 
 		expandedKey := k + "." + rangeKey
 		ports[expandedKey] = cfg
@@ -422,7 +436,7 @@ func (c *Client) processSinglePort(ports model.PortConfigList, k string, v port)
 
 	port.TLSValidate = v.TLSValidate
 	port.Tailscale = v.Tailscale
-	port.LoadBalance = v.LoadBalance
+	port.LoadBalance = c.normalizeLoadBalance(k, v.LoadBalance)
 
 	ports[k] = port
 }

--- a/internal/targetproviders/list/list_test.go
+++ b/internal/targetproviders/list/list_test.go
@@ -258,6 +258,40 @@ func TestClient_ProcessSinglePort_Valid(t *testing.T) {
 	}
 }
 
+func TestClient_GetPorts_LoadBalance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "roundrobin", raw: model.LoadBalanceRoundRobin, want: model.LoadBalanceRoundRobin},
+		{name: "unknown defaults to first", raw: "bogus", want: model.LoadBalanceFirst},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := newTestClient(t, nil)
+			ports := c.getPorts(map[string]port{
+				"443/https": {
+					LoadBalance: tc.raw,
+					Targets:     []string{"http://backend:8080"},
+				},
+			})
+
+			pc, ok := ports["443/https"]
+			if !ok {
+				t.Fatal("expected 443/https port")
+			}
+			if pc.LoadBalance != tc.want {
+				t.Errorf("expected LoadBalance=%q, got %q", tc.want, pc.LoadBalance)
+			}
+		})
+	}
+}
+
 func TestClient_GetPorts_PortRangeExpands(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds round-robin load balancing across multiple HTTP/HTTPS backends for a single proxied port. `PortConfig` already held `targets []*url.URL` but the reverse proxy always sent every request to the first target. This change lets a port spread requests across all configured targets when `loadbalance=roundrobin` is set.

## Why this matters

Issue #436 asks for spreading traffic across horizontally scaled backends. Until now each proxy effectively used one backend even when several were configured. This is Phase 1 of that request: round-robin for HTTP/HTTPS, which covers the common case. Least-conn, health-aware draining, and TCP/UDP balancing are left for follow-ups per the maintainer's request to keep the first version small.

## Changes

- `internal/model/port.go`: add a `LoadBalance` field to `PortConfig`, strategy constants (`first`, `roundrobin`), and a `SelectTarget(strategy)` method. The round-robin counter lives on `targetState` as an `atomic.Uint64` so concurrent requests rotate safely. Selection returns a deep-copied URL (same round-trip clone `GetFirstTarget` already used). Default and unknown strategies fall back to first-target, preserving today's behavior.
- `internal/proxymanager/port.go`: the HTTP/HTTPS rewrite picks the per-request target via `SelectTarget`. The management auth-token check now tests the target actually selected for the request, so the token is never forwarded to a non-management backend under round-robin.
- `internal/targetproviders/docker/`: add a `loadbalance=first|roundrobin` port option (and a `tsdproxy.loadbalance` label constant). Unknown values log a warning and default to first.
- `internal/targetproviders/list/`: add a `loadBalance` key to list-provider ports.

TCP and UDP ports continue to use the first target, so setting round-robin on them is a no-op for now.

## Testing

- `go build ./...`
- `go test ./internal/model/... ./internal/proxymanager/... ./internal/targetproviders/docker/... ./internal/targetproviders/list/... -race`

New tests cover: 3-target rotation order, single-target always-first, empty-targets returns nil without panic, unknown strategy defaults to first, returned URL is a deep copy, concurrent rotation under `-race`, and end-to-end round-robin distribution through `proxyRewrite`.

Fixes #436

AI was used for assistance.
