### PR TITLE
fix(tailscale): debounce misleading first-boot auth-failed status

### DIFF
--- a/internal/proxyproviders/tailscale/status_watcher.go
+++ b/internal/proxyproviders/tailscale/status_watcher.go
@@ -19,6 +19,16 @@ import (
 const (
 	pollInterval = 2 * time.Second
 
+	// firstBootAuthGraceCycles is the number of consecutive
+	// NeedsLogin-with-empty-authURL polls tolerated before the watcher forwards
+	// a terminal AuthFailed event. On first boot Tailscale briefly reports
+	// NeedsLogin with no auth URL while the auth key is still being processed,
+	// which otherwise surfaces a misleading "auth failed / stale state" status
+	// even though the node reaches Running moments later. The grace window keeps
+	// genuinely-bad auth keys visible (they persist past the threshold) while
+	// suppressing the transient first-boot false alarm.
+	firstBootAuthGraceCycles = 3
+
 	// Tailscale backend state strings.
 	backendStateNeedsLogin       = "NeedsLogin"
 	backendStateNoState          = "NoState"
@@ -116,6 +126,10 @@ func (w *StatusWatcher) Watch(ctx context.Context, lc *local.Client) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
+	// needsLoginNoAuthStreak counts consecutive NeedsLogin-with-empty-authURL
+	// polls so the misleading first-boot AuthFailed can be debounced.
+	needsLoginNoAuthStreak := 0
+
 	for {
 		backendState, authURL, dnsName, selfOK, err := source.getStatus(ctx)
 		if err != nil {
@@ -126,6 +140,21 @@ func (w *StatusWatcher) Watch(ctx context.Context, lc *local.Client) {
 		}
 
 		evt := classifyState(backendState, authURL, dnsName)
+
+		// Debounce the brief first-boot NeedsLogin window: while the auth key is
+		// still being processed Tailscale reports NeedsLogin with no auth URL,
+		// which classifyState maps to AuthFailed. Suppress that terminal status
+		// until it has persisted past the grace threshold, emitting a benign
+		// Starting status instead. Any other observed state resets the streak.
+		if backendState == backendStateNeedsLogin && authURL == "" {
+			needsLoginNoAuthStreak++
+			if needsLoginNoAuthStreak <= firstBootAuthGraceCycles {
+				evt = NodeEvent{Status: model.ProxyStatusStarting}
+			}
+		} else {
+			needsLoginNoAuthStreak = 0
+		}
+
 		if evt.Status == model.ProxyStatusRunning && !selfOK {
 			w.log.Warn().Msg("status watcher: Self is nil, skipping")
 		} else {

--- a/internal/proxyproviders/tailscale/status_watcher_test.go
+++ b/internal/proxyproviders/tailscale/status_watcher_test.go
@@ -251,14 +251,55 @@ func TestWatch_NeedsLogin_WithAuthURL(t *testing.T) {
 	}
 }
 
-func TestWatch_NeedsLogin_NoAuthURL(t *testing.T) {
+// waitForStatus drains events until one with the wanted status arrives or the
+// deadline elapses. It returns the matching event.
+func waitForStatus(t *testing.T, events <-chan NodeEvent, want model.ProxyStatus) NodeEvent {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case evt := <-events:
+			if evt.Status == want {
+				return evt
+			}
+		case <-deadline:
+			t.Fatalf("did not observe %v event before deadline", want)
+		}
+	}
+}
+
+// waitForStatusNoAuthFailed behaves like waitForStatus but fails the test if an
+// AuthFailed event is observed before the wanted status. This prevents a
+// debounce regression from being silently swallowed by the drain loop.
+func waitForStatusNoAuthFailed(t *testing.T, events <-chan NodeEvent, want model.ProxyStatus) NodeEvent {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case evt := <-events:
+			if evt.Status == model.ProxyStatusAuthFailed {
+				t.Fatalf("unexpected AuthFailed before %v event", want)
+			}
+			if evt.Status == want {
+				return evt
+			}
+		case <-deadline:
+			t.Fatalf("did not observe %v event before deadline", want)
+		}
+	}
+}
+
+// TestWatch_NeedsLogin_NoAuthURL_PersistsToAuthFailed verifies that a genuinely
+// stuck NeedsLogin-with-no-authURL state still surfaces AuthFailed once it has
+// persisted past the first-boot grace window, so bad auth keys are not masked.
+func TestWatch_NeedsLogin_NoAuthURL_PersistsToAuthFailed(t *testing.T) {
 	mockSrc := newMockStatusSource()
 	mockSrc.setStatusResp(statusResponse{
 		backendState: "NeedsLogin",
 		authURL:      "",
 	})
 
-	events := make(chan NodeEvent, 2)
+	events := make(chan NodeEvent, 16)
 	done := make(chan struct{}, 1)
 
 	w := NewStatusWatcher(StatusWatcherConfig{
@@ -271,13 +312,9 @@ func TestWatch_NeedsLogin_NoAuthURL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	go w.Watch(ctx, nil)
 
-	select {
-	case evt := <-events:
-		if evt.Status != model.ProxyStatusAuthFailed {
-			t.Fatalf("expected AuthFailed, got %v", evt.Status)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("no event received")
+	evt := waitForStatus(t, events, model.ProxyStatusAuthFailed)
+	if evt.ErrorMessage == "" {
+		t.Fatalf("expected error message on persisted AuthFailed")
 	}
 
 	cancel()
@@ -285,6 +322,135 @@ func TestWatch_NeedsLogin_NoAuthURL(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("onDone not called")
+	}
+}
+
+// scriptedStatusSource returns a fixed sequence of responses, one per poll,
+// repeating the final entry once the script is exhausted. This makes the exact
+// poll order deterministic regardless of the watcher's timing.
+type scriptedStatusSource struct {
+	script []statusResponse
+	idx    int
+	mu     sync.Mutex
+}
+
+func (s *scriptedStatusSource) getStatus(_ context.Context) (string, string, string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r := s.script[s.idx]
+	if s.idx < len(s.script)-1 {
+		s.idx++
+	}
+	return r.backendState, r.authURL, r.dnsName, r.selfOK, r.err
+}
+
+// TestWatch_NeedsLogin_NoAuthURL_FirstBootDebounced verifies that a transient
+// NeedsLogin-with-no-authURL window that clears to Running within the grace
+// threshold never emits the misleading AuthFailed status (issue #478).
+func TestWatch_NeedsLogin_NoAuthURL_FirstBootDebounced(t *testing.T) {
+	src := &scriptedStatusSource{script: []statusResponse{
+		{backendState: "NeedsLogin", authURL: ""},
+		{backendState: "NeedsLogin", authURL: ""},
+		{backendState: "Running", dnsName: "host.ts.net", selfOK: true},
+	}}
+
+	events := make(chan NodeEvent, 16)
+	done := make(chan struct{}, 1)
+
+	w := NewStatusWatcher(StatusWatcherConfig{
+		OnEvent:      func(evt NodeEvent) { events <- evt },
+		OnDone:       func() { done <- struct{}{} },
+		PollInterval: testPollInterval,
+	})
+	w.source = src
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go w.Watch(ctx, nil)
+
+	// Within the grace window the misleading AuthFailed is suppressed (Starting),
+	// then the node reaches Running before the threshold is crossed.
+	first := waitForStatusNoAuthFailed(t, events, model.ProxyStatusStarting)
+	if first.Status != model.ProxyStatusStarting {
+		t.Fatalf("expected Starting during grace window, got %v", first.Status)
+	}
+
+	run := waitForStatusNoAuthFailed(t, events, model.ProxyStatusRunning)
+	if run.URL != "host.ts.net" {
+		t.Fatalf("expected URL host.ts.net, got %q", run.URL)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("onDone not called")
+	}
+
+	// Drain remaining events; none should be AuthFailed.
+	for {
+		select {
+		case evt := <-events:
+			if evt.Status == model.ProxyStatusAuthFailed {
+				t.Fatalf("unexpected AuthFailed during debounced first boot")
+			}
+		default:
+			return
+		}
+	}
+}
+
+// TestWatch_NeedsLogin_NoAuthURL_StreakResets verifies that an intervening
+// non-NeedsLogin poll resets the debounce streak, so an alternating sequence
+// never prematurely trips the AuthFailed threshold.
+func TestWatch_NeedsLogin_NoAuthURL_StreakResets(t *testing.T) {
+	// Alternate NeedsLogin(no authURL) with Starting more times than the grace
+	// threshold; because the streak resets each time, AuthFailed must not fire.
+	var script []statusResponse
+	for i := 0; i < firstBootAuthGraceCycles+2; i++ {
+		script = append(script,
+			statusResponse{backendState: "NeedsLogin", authURL: ""},
+			statusResponse{backendState: "Starting"},
+		)
+	}
+	script = append(script, statusResponse{backendState: "Running", dnsName: "host.ts.net", selfOK: true})
+
+	src := &scriptedStatusSource{script: script}
+
+	events := make(chan NodeEvent, 64)
+	done := make(chan struct{}, 1)
+
+	w := NewStatusWatcher(StatusWatcherConfig{
+		OnEvent:      func(evt NodeEvent) { events <- evt },
+		OnDone:       func() { done <- struct{}{} },
+		PollInterval: testPollInterval,
+	})
+	w.source = src
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go w.Watch(ctx, nil)
+
+	// Wait until the script reaches Running, proving we polled past the grace
+	// threshold's worth of NeedsLogin entries without ever emitting AuthFailed.
+	// The strict helper fails if any AuthFailed slips through rather than
+	// silently discarding it.
+	waitForStatusNoAuthFailed(t, events, model.ProxyStatusRunning)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("onDone not called")
+	}
+
+	for {
+		select {
+		case evt := <-events:
+			if evt.Status == model.ProxyStatusAuthFailed {
+				t.Fatalf("AuthFailed fired despite streak resets")
+			}
+		default:
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

On every first boot, tsdproxy logs a scary, terminal-sounding status: `tailscale is in NeedsLogin state without an auth URL. This indicates stale tsnet state ... Restart tsdproxy to auto-recover` (#478). The node is actually authenticating fine and reaches `Running` moments later, so the message is misleading.

The cause is in `internal/proxyproviders/tailscale/status_watcher.go`. During the brief first-boot window, `lc.Status()` reports backend state `NeedsLogin` with an empty `authURL` because the auth key has not been processed yet. `classifyState` maps that combination straight to a terminal `model.ProxyStatusAuthFailed` event, which is what surfaces as the alarming message.

This change keeps `classifyState` pure and adds a small debounce in `StatusWatcher.Watch`: it counts consecutive `NeedsLogin`-with-empty-`authURL` polls and emits the benign `ProxyStatusStarting` status until the streak persists past a grace threshold (`firstBootAuthGraceCycles`, default 3 poll cycles). Only once the threshold is crossed does it forward `ProxyStatusAuthFailed`. Any other observed state (or a non-empty `authURL`) resets the counter. The default is an internal constant, so `NewStatusWatcher` and the `node_lifecycle.go` call sites need no signature change.

## Why this matters

The maintainer flagged this twice in the thread: the node was confirmed to be authenticating correctly, and the conclusion was that the status watcher polls during the normal first-boot `NeedsLogin` window and emits a misleading message that should be improved. Genuinely-bad auth keys are not masked, because a `NeedsLogin`-with-no-`authURL` state that persists past the grace window still surfaces `AuthFailed` with the existing error message.

## Testing

- `go test ./internal/proxyproviders/tailscale/...` (and `-race`) pass.
- Added watcher tests covering: transient first-boot window that clears to `Running` emits no `AuthFailed`; a persisted `NeedsLogin`-no-`authURL` state still surfaces `AuthFailed`; an alternating sequence resets the streak and never trips the threshold prematurely.
- The existing pure `classifyState` table tests are unchanged and still pass.

Refs #478
